### PR TITLE
Introduce a parser error when the *same* custom op trait is used more than once

### DIFF
--- a/lib/_007/Parser/Actions.pm
+++ b/lib/_007/Parser/Actions.pm
@@ -168,7 +168,11 @@ class _007::Parser::Actions {
     }
 
     method traitlist($/) {
-        make Q::TraitList.new(:traits(Val::Array.new(:elements($<trait>».ast))));
+        my @traits = $<trait>».ast;
+        if bag( @traits.map: *.ident.name.value ).grep( *.value > 1 )[0] -> $p {
+             die X::Trait::Duplicate.new: :t($p.key)
+        }
+        make Q::TraitList.new(:traits(Val::Array.new(:elements(@traits))));
     }
     method trait($/) {
         make Q::Trait.new(:ident($<identifier>.ast), :expr($<EXPR>.ast));

--- a/lib/_007/Parser/Exceptions.pm
+++ b/lib/_007/Parser/Exceptions.pm
@@ -13,6 +13,12 @@ class X::Trait::Conflict is Exception {
     method message { "Traits '$.t1' and '$.t2' cannot coexist on the same routine" }
 }
 
+class X::Trait::Duplicate is Exception {
+    has Str $.t;
+
+    method message { "Trait '$.t' is used more than once" }
+}
+
 class X::Op::Nonassociative is Exception {
     has Str $.op1;
     has Str $.op2;

--- a/t/features/custom-ops.t
+++ b/t/features/custom-ops.t
@@ -168,6 +168,16 @@ use _007::Test;
 
 {
     my $program = q:to/./;
+        sub infix:<!?!>(left, right) is equal(infix:<+>) is equal(infix:<*>) {
+        }
+        .
+
+    parse-error $program, X::Trait::Duplicate, "can't use the same trait more than once";
+}
+
+
+{
+    my $program = q:to/./;
         sub infix:<@>(left, right) {
             return "@";
         }


### PR DESCRIPTION
Regarding https://github.com/masak/007/issues/95