### PR TITLE
fix substr, add prefix and suffix methods

### DIFF
--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -311,12 +311,23 @@ class _007::Runtime {
             });
         }
         elsif $obj ~~ Val::Str && $propname eq "substr" {
-            return Val::Sub::Builtin.new("substr", sub ($pos, $chars?) {
+            return Val::Sub::Builtin.new("substr", sub ($pos, $chars) {
                 return Val::Str.new(:value($obj.value.substr(
                     $pos.value,
-                    $chars.defined
-                        ?? $chars.value
-                        !! $obj.value.chars)));
+                    $chars.value)));
+            });
+        }
+        elsif $obj ~~ Val::Str && $propname eq "prefix" {
+            return Val::Sub::Builtin.new("prefix", sub ($pos) {
+                return Val::Str.new(:value($obj.value.substr(
+                    0,
+                    $pos.value + 1)));
+            });
+        }
+        elsif $obj ~~ Val::Str && $propname eq "suffix" {
+            return Val::Sub::Builtin.new("suffix", sub ($pos) {
+                return Val::Str.new(:value($obj.value.substr(
+                    $pos.value)));
             });
         }
         elsif $obj ~~ Val::Str && $propname eq "charat" {

--- a/t/features/builtins/methods.t
+++ b/t/features/builtins/methods.t
@@ -141,11 +141,28 @@ use _007::Test;
     my $ast = q:to/./;
         (statementlist
           (stexpr (postfix:<()> (identifier "say") (argumentlist (postfix:<()> (postfix:<.> (str "abc") (identifier "substr")) (argumentlist (int 0) (int 1))))))
-          (stexpr (postfix:<()> (identifier "say") (argumentlist (postfix:<()> (postfix:<.> (str "abc") (identifier "substr")) (argumentlist (int 1))))))
           (stexpr (postfix:<()> (identifier "say") (argumentlist (postfix:<()> (postfix:<.> (str "abc") (identifier "substr")) (argumentlist (int 0) (int 5)))))))
         .
 
-    is-result $ast, "a\nbc\nabc\n", "substr() works";
+    is-result $ast, "a\nabc\n", "substr() works";
+}
+
+{
+    my $ast = q:to/./;
+        (statementlist
+          (stexpr (postfix:<()> (identifier "say") (argumentlist (postfix:<()> (postfix:<.> (str "abc") (identifier "prefix")) (argumentlist (int 1)))))))
+        .
+
+    is-result $ast, "ab\n", "prefix() works";
+}
+
+{
+    my $ast = q:to/./;
+        (statementlist
+          (stexpr (postfix:<()> (identifier "say") (argumentlist (postfix:<()> (postfix:<.> (str "abc") (identifier "suffix")) (argumentlist (int 1)))))))
+        .
+
+    is-result $ast, "bc\n", "suffix() works";
 }
 
 {


### PR DESCRIPTION
make substr take 3 arguments (no optional args), add prefix and suffix methods accordingly
closes #113