### PR TITLE
Allow trailing commas in objects, argument lists, and parameter lists

### DIFF
--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -234,7 +234,7 @@ grammar _007::Parser::Syntax {
         <.finishpad>
     }
 
-    token propertylist { [<.ws> <property>]* % [\h* ','] <.ws> }
+    token propertylist { [<.ws> <property>]* %% [\h* ','] <.ws> }
 
     token unquote { '{{{' <EXPR> [:s "@" <identifier> ]? '}}}' }
 
@@ -292,13 +292,13 @@ grammar _007::Parser::Syntax {
     }
 
     rule argumentlist {
-        <EXPR> *% ','
+        <EXPR> *%% ','
     }
 
     rule parameterlist {
         [<parameter>
         { declare(Q::Parameter, $<parameter>[*-1]<identifier>.Str); }
-        ]* % ','
+        ]* %% ','
     }
 
     rule parameter {

--- a/t/features/objects.t
+++ b/t/features/objects.t
@@ -6,6 +6,7 @@ use _007::Test;
     my @exprs = «
         '{}'  '(object (identifier "Object") (propertylist))'
         '{"a": 1}' '(object (identifier "Object") (propertylist (property "a" (int 1))))'
+        '{"a": 1,}' '(object (identifier "Object") (propertylist (property "a" (int 1))))'
         '{a}' '(object (identifier "Object") (propertylist (property "a" (identifier "a"))))'
         '{a : 1}' '(object (identifier "Object") (propertylist (property "a" (int 1))))'
         '{ a: 1}' '(object (identifier "Object") (propertylist (property "a" (int 1))))'

--- a/t/features/subs.t
+++ b/t/features/subs.t
@@ -207,4 +207,24 @@ use _007::Test;
         "...but not outside of the sub";
 }
 
+{
+    my $program = q:to/./;
+        sub f(x,) { }
+        sub g(x,y,) { }
+        .
+
+    outputs $program, "", "trailing commas are allowed in parameterlist";
+}
+
+{
+    my $program = q:to/./;
+        sub f(x)   { say(1) }
+        sub g(x,y) { say(2) }
+        f(4,);
+        g(4,5,);
+        .
+
+    outputs $program, "1\n2\n", "...and in argumentlist";
+}
+
 done-testing;


### PR DESCRIPTION
With tests, of course :) Fixes #91