### PR TITLE
WIP: Feature #174 – basic regex structure

### DIFF
--- a/lib/_007/Parser/Actions.pm
+++ b/lib/_007/Parser/Actions.pm
@@ -553,7 +553,7 @@ class _007::Parser::Actions {
     }
 
     method term:regex ($/) {
-        make Q::Term::Regex.new(:contents($<contents>.made));
+        make Q::Term::Regex.new(:contents($<contents>.ast.value));
     }
 
     method term:identifier ($/) {

--- a/lib/_007/Parser/Actions.pm
+++ b/lib/_007/Parser/Actions.pm
@@ -552,6 +552,10 @@ class _007::Parser::Actions {
         make $<EXPR>.ast;
     }
 
+    method term:regex ($/) {
+        make Q::Term::Regex.new(:contents($<contents>.made));
+    }
+
     method term:identifier ($/) {
         make $<identifier>.ast;
         my $name = $<identifier>.ast.name.value;

--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -186,7 +186,7 @@ grammar _007::Parser::Syntax {
         '/' ~ '/'
         [
             { check-feature-flag("regex syntax", "REGEX"); }
-            <contents=term:str>
+            <contents=str>
         ]
     }
     token term:quasi { quasi <.ws>

--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -182,6 +182,13 @@ grammar _007::Parser::Syntax {
     token term:array { '[' ~ ']' [[<.ws> <EXPR>]* %% [\h* ','] <.ws>] }
     token term:str { <str> }
     token term:parens { '(' ~ ')' <EXPR> }
+    token term:regex {
+        '/' ~ '/'
+        [
+            { check-feature-flag("regex syntax", "REGEX"); }
+            <contents=term:str>
+        ]
+    }
     token term:quasi { quasi <.ws>
         [
             || "@" <.ws> $<qtype>=["Q::Infix"] <.ws> '{' <.ws> <infix> <.ws> '}'

--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -185,7 +185,7 @@ grammar _007::Parser::Syntax {
     token term:regex {
         '/' ~ '/'
         [
-            { check-feature-flag("regex syntax", "REGEX"); }
+            { check-feature-flag("Regex syntax", "REGEX"); }
             <contents=str>
         ]
     }

--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -172,7 +172,7 @@ grammar _007::Parser::Syntax {
         return /<!>/(self);
     }
 
-    token str { '"' ([<-["]> | '\\\\' | '\\"']*) '"' }
+    token str { '"' ([<-["]> | '\\\\' | '\\"']*) '"' } # " you are welcome vim
 
     proto token term {*}
     token term:none { None» }

--- a/lib/_007/Q.pm
+++ b/lib/_007/Q.pm
@@ -129,10 +129,10 @@ class Q::Identifier does Q::Term {
 }
 
 class Q::Term::Regex does Q::Term {
-    has Q::Literal::Str $.contents;
+    has Val::Str $.contents;
 
     method eval($runtime) {
-        Val::Regex.new(:contents($<contents>.eval($runtime)));
+        Val::Regex.new(:contents($.contents));
     }
 }
 

--- a/lib/_007/Q.pm
+++ b/lib/_007/Q.pm
@@ -41,6 +41,10 @@ class X::Associativity::Conflict is Exception {
     method message { "The operator already has a defined associativity" }
 }
 
+class X::Regex::InvalidMatchType is Exception {
+    method message { "A regex can only match strings" }
+}
+
 class X::_007::RuntimeException is Exception {
     has $.msg;
 
@@ -121,6 +125,14 @@ class Q::Identifier does Q::Term {
 
     method put-value($value, $runtime) {
         $runtime.put-var(self, $value);
+    }
+}
+
+class Q::Term::Regex does Q::Term {
+    has Q::Literal::Str $.contents;
+
+    method eval($runtime) {
+        Val::Regex.new(:contents($<contents>.eval($runtime)));
     }
 }
 

--- a/lib/_007/Q.pm
+++ b/lib/_007/Q.pm
@@ -132,7 +132,7 @@ class Q::Term::Regex does Q::Term {
     has Val::Str $.contents;
 
     method eval($runtime) {
-        Val::Regex.new(:contents($.contents));
+        Val::Regex.new(:$.contents);
     }
 }
 

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -350,7 +350,6 @@ class _007::Runtime {
         }
         elsif $obj ~~ Val::Regex && $propname eq "fullmatch" {
             return builtin(sub fullmatch($str) {
-                #dd $obj, $str;
                 my $regex-string = $obj.contents.value;
 
                 die X::Regex::InvalidMatchType.new

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -348,6 +348,26 @@ class _007::Runtime {
                 return Val::Str.new(:value($s.substr($pos.value, 1)));
             });
         }
+        elsif $obj ~~ Val::Regex && $propname eq "fullmatch" {
+            return builtin(sub fullmatch($str) {
+                my $regex-string = $obj.contents.value;
+
+                die X::Regex::InvalidMatchType.new
+                    unless $str ~~ Val::Str;
+
+                return Val::Bool.new($regex-string eq $str.value);
+            }
+        }
+        elsif $obj ~~ Val::Regex && $propname eq "search" {
+            return builtin(sub fullmatch($str) {
+                my $regex-string = $obj.contents.value;
+
+                die X::Regex::InvalidMatchType.new
+                    unless $str ~~ Val::Str;
+
+                return Val::Bool.new($str.value.contains($regex-string));
+            }
+        }
         elsif $obj ~~ Val::Array && $propname eq "filter" {
             return builtin(sub filter($fn) {
                 my @elements = $obj.elements.grep({ self.call($fn, [$_]).truthy });

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -356,7 +356,7 @@ class _007::Runtime {
                     unless $str ~~ Val::Str;
 
                 return Val::Bool.new($regex-string eq $str.value);
-            }
+            });
         }
         elsif $obj ~~ Val::Regex && $propname eq "search" {
             return builtin(sub fullmatch($str) {
@@ -366,7 +366,7 @@ class _007::Runtime {
                     unless $str ~~ Val::Str;
 
                 return Val::Bool.new($str.value.contains($regex-string));
-            }
+            });
         }
         elsif $obj ~~ Val::Array && $propname eq "filter" {
             return builtin(sub filter($fn) {

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -350,12 +350,13 @@ class _007::Runtime {
         }
         elsif $obj ~~ Val::Regex && $propname eq "fullmatch" {
             return builtin(sub fullmatch($str) {
+                #dd $obj, $str;
                 my $regex-string = $obj.contents.value;
 
                 die X::Regex::InvalidMatchType.new
                     unless $str ~~ Val::Str;
 
-                return Val::Bool.new($regex-string eq $str.value);
+                return Val::Bool.new(:value($regex-string eq $str.value));
             });
         }
         elsif $obj ~~ Val::Regex && $propname eq "search" {
@@ -365,7 +366,7 @@ class _007::Runtime {
                 die X::Regex::InvalidMatchType.new
                     unless $str ~~ Val::Str;
 
-                return Val::Bool.new($str.value.contains($regex-string));
+                return Val::Bool.new(:value($str.value.contains($regex-string)));
             });
         }
         elsif $obj ~~ Val::Array && $propname eq "filter" {

--- a/lib/_007/Test.pm
+++ b/lib/_007/Test.pm
@@ -13,6 +13,7 @@ sub read(Str $ast) is export {
         str            => Q::Literal::Str,
         array          => Q::Term::Array,
         object         => Q::Term::Object,
+        regex          => Q::Term::Regex,
         sub            => Q::Term::Sub,
         quasi          => Q::Term::Quasi,
 

--- a/lib/_007/Val.pm
+++ b/lib/_007/Val.pm
@@ -59,10 +59,6 @@ class Val::Regex does Val {
     method quoted-Str {
         "/" ~ $.contents.quoted-Str ~ "/"
     }
-
-    method truthy {
-        True
-    }
 }
 
 class Val::Array does Val {

--- a/lib/_007/Val.pm
+++ b/lib/_007/Val.pm
@@ -53,6 +53,18 @@ class Val::Str does Val {
     }
 }
 
+class Val::Regex does Val {
+    has Val::Str $.contents;
+
+    method quoted-Str {
+        "/" ~ $.contents.quoted-Str ~ "/"
+    }
+
+    method truthy {
+        True
+    }
+}
+
 class Val::Array does Val {
     has @.elements;
 
@@ -181,6 +193,7 @@ class Helper {
         when Val::Bool { .value.Str }
         when Val::Int { .value.Str }
         when Val::Str { .value }
+        when Val::Regex { .quoted-Str }
         when Val::Array { .quoted-Str }
         when Val::Object { .quoted-Str }
         when Val::Type { "<type {.name}>" }

--- a/t/features/builtins/methods.t
+++ b/t/features/builtins/methods.t
@@ -309,5 +309,47 @@ use _007::Test;
     is-result $ast, "True\nFalse\n", "String.contains() works";
 }
 
+{
+    my $program = q:to/./;
+        (statementlist
+          (my (identifier "r") (regex "hey"))
+          (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (postfix:. (identifier "r") (identifier "fullmatch")) (argumentlist (str "hey"))))))
+          (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (postfix:. (identifier "r") (identifier "fullmatch")) (argumentlist (str "hi")))))))
+        .
+
+    is-result $program, "True\nFalse\n", "Regex.fullmatch() works positively and negatively";
+}
+
+{
+    my $program = q:to/./;
+        (statementlist
+          (my (identifier "r") (regex "hey"))
+          (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (postfix:. (identifier "r") (identifier "search")) (argumentlist (str "Oh, hey you!"))))))
+          (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (postfix:. (identifier "r") (identifier "search")) (argumentlist (str "Well, hi there.")))))))
+        .
+
+    is-result $program, "True\nFalse\n", "Regex.search() works positively and negatively";
+}
+
+{
+    my $ast = q:to/./;
+        (statementlist
+          (my (identifier "r") (regex "word"))
+          (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (postfix:. (identifier "r") (identifier "fullmatch")) (argumentlist (int 3)))))))
+        .
+
+    is-error $ast, X::Regex::InvalidMatchType, "Regex.fullmatch() can only match strings";
+}
+
+{
+    my $ast = q:to/./;
+        (statementlist
+          (my (identifier "r") (regex "word"))
+          (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (postfix:. (identifier "r") (identifier "search")) (argumentlist (int 3)))))))
+        .
+
+    is-error $ast, X::Regex::InvalidMatchType, "Regex.search() can only match strings";
+}
+
 done-testing;
 


### PR DESCRIPTION
 - [x] A definition of token term:regex in Syntax.pm.
      - [x] It should recognize a term:str inside /.../ slashes, and nothing else for now. Let's iterate and extend on it bit by bit in later PRs. (I learned this from the object literal PR, which could've been broken up into smaller morsels.)
      - [x] It should be hidden behind a feature flag. See 2759902 for prior art.
 - [x] A corresponding term:regex method in Actions.pm.
 - [x] A new Q type Q::Term::Regex (not Regexp) in Q.pm.
      - Haven't given the internal structure any thought. It's up for demo/discussion.
 - [x] A new value type Val::Regex in Val.pm.
 - [x] Two methods on Val::Regex (in Runtime.pm):
      - [x] fullmatch(str) that returns True if the entire str matches the regex
      - [x] search(str) that returns True if str.index(regex_str) != -1
 - [x] Tests for both methods (positive and negative). So, four tests, I guess. 2759902 also has prior art for how to test behind a feature flag.