### PR TITLE
Make 'macro statement:foo' and 'is parsed' work

### DIFF
--- a/lib/_007/Parser/Actions.pm
+++ b/lib/_007/Parser/Actions.pm
@@ -259,6 +259,13 @@ class _007::Parser::Actions {
         $identifier.put-value($val, $*runtime);
     }
 
+    method statement:custom ($/) {
+        my $macro = $*runtime.maybe-get-var("statement:whoa");
+        make expand($macro, [],
+            # XXX: this is rather doubtful -- but there's simply no right answer to "what's the unexpanded form?"
+            -> { });
+    }
+
     method traitlist($/) {
         my @traits = $<trait>».ast;
         if bag( @traits.map: *.identifier.name.value ).grep( *.value > 1 )[0] -> $p {
@@ -316,7 +323,13 @@ class _007::Parser::Actions {
         if $*unexpanded {
             return &unexpanded-callback();
         }
-        else {
+        return $expansion;
+    }
+
+    sub expand-expr($macro, @arguments, &unexpanded-callback:()) {
+        my $expansion = expand($macro, @arguments, &unexpanded-callback);
+
+        if !$*unexpanded {
             if $expansion ~~ Q::Statement {
                 $expansion = Q::StatementList.new(:statements(Val::Array.new(:elements([$expansion]))));
             }
@@ -331,9 +344,9 @@ class _007::Parser::Actions {
             if $expansion ~~ Q::Block {
                 $expansion = Q::Expr::StatementListAdapter.new(:statementlist($expansion.statementlist));
             }
-
-            return $expansion;
         }
+
+        return $expansion;
     }
 
     method EXPR($/) {
@@ -370,7 +383,7 @@ class _007::Parser::Actions {
             }
 
             if my $macro = is-macro($infix, Q::Infix, $infix.identifier) {
-                @termstack.push(expand($macro, [$t1, $t2],
+                @termstack.push(expand-expr($macro, [$t1, $t2],
                     -> { $infix.new(:lhs($t1), :rhs($t2), :identifier($infix.identifier)) }));
             }
             else {
@@ -442,7 +455,7 @@ class _007::Parser::Actions {
             }
 
             if my $macro = is-macro($prefix, Q::Prefix, $prefix.identifier) {
-                make expand($macro, [$/.ast],
+                make expand-expr($macro, [$/.ast],
                     -> { $prefix.new(:operand($/.ast), :identifier($prefix.identifier)) });
             }
             else {
@@ -454,7 +467,7 @@ class _007::Parser::Actions {
             my $postfix = @postfixes.shift.ast;
             my $identifier = $postfix.identifier;
             if my $macro = is-macro($postfix, Q::Postfix::Call, $/.ast) {
-                make expand($macro, $postfix.argumentlist.arguments.elements,
+                make expand-expr($macro, $postfix.argumentlist.arguments.elements,
                     -> { $postfix.new(:$identifier, :operand($/.ast), :argumentlist($postfix.argumentlist)) });
             }
             elsif $postfix ~~ Q::Postfix::Index {
@@ -468,7 +481,7 @@ class _007::Parser::Actions {
             }
             else {
                 if my $macro = is-macro($postfix, Q::Postfix, $identifier) {
-                    make expand($macro, [$/.ast],
+                    make expand-expr($macro, [$/.ast],
                         -> { $postfix.new(:$identifier, :operand($/.ast)) });
                 }
                 else {

--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -117,6 +117,9 @@ grammar _007::Parser::Syntax {
         { declare(Q::Statement::Class, $<identifier>.ast.name.value); }
         <block>
     }
+    token statement:custom {
+        "whoa!"
+    }
 
     rule traitlist {
         <trait> *

--- a/t/features/is-parsed.t
+++ b/t/features/is-parsed.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+use _007::Test;
+
+{
+    my $program = q:to/./;
+        macro statement:<whoa>() is parsed(/"whoa!"/) {
+            return quasi @ Q::Statement {
+                say("whoa!");
+            }
+        };
+
+        whoa!;
+        .
+
+    outputs
+        $program,
+        "whoa!\n",
+        "an is-parsed statement macro gets installed and participates in parsing";
+}
+
+done-testing;


### PR DESCRIPTION
*This is a work in progress.*

Addresses #177.

Still hardcoding various things in here, and definitely not ready to merge this one, but I still wanted to share because I discovered/realized various things.

## Do not merge before the following

* For one thing, the refactor #242. It's much easier for that one to land and then we rebase this one, than the other way around.
* Also, @vendethiel's work in #239. This solution is going to need to change based on the ways regexes expand and become more powerful. Specifically, see https://github.com/masak/007/pull/239#discussion_r138255903.

## What I realized

* We're going to have to register/store custom statements just the same as we do operators. The logical place to do this is `OpScope`. (Which indicates "opscope" is perhaps not the best name for it!) Not a big problem in itself, but I hadn't thought about this before. *All* the categories that can be declared/extended in 007 will need to end up in an opscope-like thing.

* (The big one:) The `statement:whoa` thing is not a macro *expansion* as such. An expansion is an AST → AST transformation. But `statement:whoa` transforms from textual source directly to AST. Proximally, this means that there's no "unexpanded AST" that the parser can produce for this statement. What could we reasonably put there? A blank `Q::Statement`? (Then we cannot make `Q::Statement` an abstract type.)

* Also, excitingly, I had to split the utility method `expand` in Actions.pm into `expand` (for this use case) and `expand-expr` (for all the previous ones). It turns out we've only ever expanded macros into an expression, but in this case we're expanding it into a statementlist. In that case, we are not supposed to do the dance of wrapping things into a `Q::Expr::StatementListAdapter`.