### PR TITLE
Allow '{{{' to happen first in a statement

### DIFF
--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -64,7 +64,7 @@ grammar _007::Parser::Syntax {
         ['=' <EXPR>]?
     }
     token statement:expr {
-        <![{]>       # }], you're welcome vim
+        <!before <!before '{{{'> '{'>   # } }}}, you're welcome vim
         <EXPR>
     }
     token statement:block { <pblock> }

--- a/t/features/unquote.t
+++ b/t/features/unquote.t
@@ -148,4 +148,18 @@ use _007::Test;
     outputs $program, "<type Q::CompUnit>\n", "Q::CompUnit @ q";
 }
 
+{
+    my $program = q:to/./;
+        macro moo(a, b) {
+            return quasi { {{{a}}} = {{{b}}} }
+        }
+
+        my x = 5;
+        moo(x, "007");
+        say(x);
+        .
+
+    outputs $program, "007\n", "unquote parses first in statement";
+}
+
 done-testing;


### PR DESCRIPTION
Closes #287.

As described in that issue, a statement starting with an unquote '{{{'
wouldn't parse properly. This was a bug, ultimately caused by the
fact that a statement starting with a '{' was deemed to *not* be an
expression statement.

The reason for this latter rule is that '{' starting a statement
introduces a *statement block*, like so:

    {
        my thing = "statement block";
        say("Hello, I'm a " ~ thing);
    }

The same disambiguation technique exists in Perl 5, Perl 6, and
JavaScript: '{' starts an object literal, except at the start of a
statement where it starts a statement block.

(Confounsing factor: I used to be able to demonstrate this as
parsing errors in Chrome Devtools, Firefox, and Node -- but all these
have lately improved their CLI parsing to introduce exceptions so
that it magically understands your intent and prefers object
literals. This also breaks some of the examples from the WAT talk.)

Fortunately, LTM offers us an out here: a '{{{' "token" is not a
type of '{' token, and so we should only disallow the former, not
the latter. It's quite unambiguously the case that '{' can not
occur at the start of an expression statement, but '{{{' *can*.