### PR TITLE
Change "sub" to "func" everywhere

### DIFF
--- a/examples/99-bottles.007
+++ b/examples/99-bottles.007
@@ -1,5 +1,5 @@
-sub verse(n) {
-    sub plural(n, thing) {
+func verse(n) {
+    func plural(n, thing) {
         if n == 1 {
             return ~n ~ " " ~ thing;
         }

--- a/examples/euclid-gcd.007
+++ b/examples/euclid-gcd.007
@@ -1,4 +1,4 @@
-sub gcd(a, b) {
+func gcd(a, b) {
     if b {
         return gcd(b, a % b);
     }

--- a/examples/format.007
+++ b/examples/format.007
@@ -1,6 +1,6 @@
 macro format(fmt, args) {
-    sub replaceAll(input, transform) {
-        sub helper(input, output) {
+    func replaceAll(input, transform) {
+        func helper(input, output) {
             if !input.contains("{") {
                 return output ~ input;
             }
@@ -17,7 +17,7 @@ macro format(fmt, args) {
         return helper(input, "");
     }
 
-    sub findHighestIndex(input) {
+    func findHighestIndex(input) {
         my openBracePos = input.index("{");
         if openBracePos == -1 {
             return -1;
@@ -48,7 +48,7 @@ macro format(fmt, args) {
     }
 
     return quasi {
-        replaceAll({{{fmt}}}, sub transform(arg) {
+        replaceAll({{{fmt}}}, func transform(arg) {
             return {{{args}}}[+arg];
         });
     }

--- a/examples/hanoi.007
+++ b/examples/hanoi.007
@@ -13,7 +13,7 @@ my state = [
     []
 ];
 
-sub tw(n, L) {
+func tw(n, L) {
     my e = state[n].size();
     if L >= e {
         return PIN;
@@ -21,13 +21,13 @@ sub tw(n, L) {
     return state[n][L];
 }
 
-sub show() {
+func show() {
     for (^5).reverse() -> L {
         say(tw(0, L) ~ " " ~ tw(1, L) ~ " " ~ tw(2, L));
     }
 }
 
-sub move(diskname, from, to) {
+func move(diskname, from, to) {
     say("");
     say("Moving " ~ diskname ~ " from pile " ~ ~(from + 1) ~ " to pile " ~ ~(to + 1) ~ "...");
     say("");
@@ -36,7 +36,7 @@ sub move(diskname, from, to) {
     show();
 }
 
-sub solve_hanoi(n, from, helper, to) {
+func solve_hanoi(n, from, helper, to) {
     if n >= 2 {
         solve_hanoi(n - 1, from, to, helper);
     }

--- a/examples/quicksort.007
+++ b/examples/quicksort.007
@@ -1,4 +1,4 @@
-sub quicksort(array) {
+func quicksort(array) {
     if array.size() > 1 {
         my pivot = array[0];
         my less = [];

--- a/examples/x-and-xx.007
+++ b/examples/x-and-xx.007
@@ -1,5 +1,5 @@
 macro infix:<xx>(left, right) is equal(infix:<*>) {
-    sub flatten(array) {
+    func flatten(array) {
         my result = [];
         for array -> elem {
             if elem ~~ Array {
@@ -12,13 +12,13 @@ macro infix:<xx>(left, right) is equal(infix:<*>) {
     }
 
     return quasi {
-        flatten((^{{{right}}}).map(sub(_) {
+        flatten((^{{{right}}}).map(func(_) {
             return {{{left}}};
         }))
     }
 }
 
-sub infix:<x>(left, right) is equal(infix:<*>) {
+func infix:<x>(left, right) is equal(infix:<*>) {
     return (left xx right).join("");
 }
 

--- a/lib/_007/Builtins.pm
+++ b/lib/_007/Builtins.pm
@@ -49,7 +49,7 @@ sub builtins(:$input!, :$output!, :$opscope!) is export {
     multi equal-value(Val::Type $l, Val::Type $r) {
         $l.type === $r.type
     }
-    multi equal-value(Val::Sub $l, Val::Sub $r) {
+    multi equal-value(Val::Func $l, Val::Func $r) {
         $l.name eq $r.name
             && equal-value($l.parameterlist, $r.parameterlist)
             && equal-value($l.statementlist, $r.statementlist)
@@ -386,7 +386,7 @@ sub builtins(:$input!, :$output!, :$opscope!) is export {
             my @elements = .value.signature.params».name».&ditch-sigil».&parameter;
             my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
             my $statementlist = Q::StatementList.new();
-            .key => Val::Sub.new-builtin(.value, .key, $parameterlist, $statementlist);
+            .key => Val::Func.new-builtin(.value, .key, $parameterlist, $statementlist);
         }
         when .value ~~ Placeholder::MacroOp {
             my $name = .key;
@@ -394,7 +394,7 @@ sub builtins(:$input!, :$output!, :$opscope!) is export {
             my @elements = .value.qtype.attributes».name».substr(2).grep({ $_ ne "identifier" })».&parameter;
             my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
             my $statementlist = Q::StatementList.new();
-            .key => Val::Sub.new-builtin(sub () {}, $name, $parameterlist, $statementlist);
+            .key => Val::Func.new-builtin(sub () {}, $name, $parameterlist, $statementlist);
         }
         when .value ~~ Placeholder::Op {
             my $name = .key;
@@ -403,7 +403,7 @@ sub builtins(:$input!, :$output!, :$opscope!) is export {
             my @elements = &fn.signature.params».name».&ditch-sigil».&parameter;
             my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
             my $statementlist = Q::StatementList.new();
-            .key => Val::Sub.new-builtin(&fn, $name, $parameterlist, $statementlist);
+            .key => Val::Func.new-builtin(&fn, $name, $parameterlist, $statementlist);
         }
         default { die "Unknown type {.value.^name}" }
     };

--- a/lib/_007/Linter.pm
+++ b/lib/_007/Linter.pm
@@ -70,8 +70,8 @@ class _007::Linter {
                 }
             }
 
-            multi traverse(Q::Statement::Sub $sub) {
-                my $name = $sub.identifier.name;
+            multi traverse(Q::Statement::Func $func) {
+                my $name = $func.identifier.name;
                 %declared{"{@blocks[*-1].WHICH.Str}|$name"} = L::SubNotUsed;
             }
 

--- a/lib/_007/Parser.pm
+++ b/lib/_007/Parser.pm
@@ -15,7 +15,7 @@ class _007::Parser {
     method parse($program, Bool :$*unexpanded) {
         my %*assigned;
         my @*declstack;
-        my $*insub = False;
+        my $*in_routine = False;
         my $*parser = self;
         my $*runtime = $!runtime;
         @!checks = ();

--- a/lib/_007/Parser/Actions.pm
+++ b/lib/_007/Parser/Actions.pm
@@ -120,7 +120,7 @@ class _007::Parser::Actions {
         if $<EXPR>.ast ~~ Q::Block {
             make Q::Statement::Expr.new(:expr(Q::Postfix::Call.new(
                 :identifier(Q::Identifier.new(:name(Val::Str.new(:value("postfix:()"))))),
-                :operand(Q::Term::Sub.new(:identifier(NONE), :block($<EXPR>.ast))),
+                :operand(Q::Term::Func.new(:identifier(NONE), :block($<EXPR>.ast))),
                 :argumentlist(Q::ArgumentList.new)
             )));
         }
@@ -184,7 +184,7 @@ class _007::Parser::Actions {
         $*parser.opscope.install($type, $op, :%precedence, :$assoc);
     }
 
-    method statement:sub-or-macro ($/) {
+    method statement:func-or-macro ($/) {
         my $identifier = $<identifier>.ast;
         my $name = $<identifier>.ast.name;
         my $parameterlist = $<parameterlist>.ast;
@@ -197,9 +197,9 @@ class _007::Parser::Actions {
 
         my $outer-frame = $*runtime.current-frame;
         my $val;
-        if $<routine> eq "sub" {
-            make Q::Statement::Sub.new(:$identifier, :$traitlist, :$block);
-            $val = Val::Sub.new(:$name, :$parameterlist, :$statementlist, :$outer-frame, :$static-lexpad);
+        if $<routine> eq "func" {
+            make Q::Statement::Func.new(:$identifier, :$traitlist, :$block);
+            $val = Val::Func.new(:$name, :$parameterlist, :$statementlist, :$outer-frame, :$static-lexpad);
         }
         elsif $<routine> eq "macro" {
             make Q::Statement::Macro.new(:$identifier, :$traitlist, :$block);
@@ -216,7 +216,7 @@ class _007::Parser::Actions {
 
     method statement:return ($/) {
         die X::ControlFlow::Return.new
-            unless $*insub;
+            unless $*in_routine;
         make Q::Statement::Return.new(:expr($<EXPR> ?? $<EXPR>.ast !! NONE));
     }
 
@@ -605,7 +605,7 @@ class _007::Parser::Actions {
                 die X::Macro::Postdeclared.new(:$name)
                     if $value ~~ Val::Macro;
                 die X::Undeclared.new(:symbol($name))
-                    unless $value ~~ Val::Sub;
+                    unless $value ~~ Val::Func;
             };
         }
     }
@@ -664,7 +664,7 @@ class _007::Parser::Actions {
         die "Got something in a quasi that we didn't expect: {$/.keys}";   # should never happen
     }
 
-    method term:sub ($/) {
+    method term:func ($/) {
         my $parameterlist = $<parameterlist>.ast;
         my $traitlist = $<traitlist>.ast;
         my $statementlist = $<blockoid>.ast;
@@ -674,7 +674,7 @@ class _007::Parser::Actions {
             my $name = $<identifier>.ast.name;
             my $outer-frame = $*runtime.current-frame.properties<outer-frame>;
             my $static-lexpad = $*runtime.current-frame.properties<pad>;
-            my $val = Val::Sub.new(:$name, :$parameterlist, :$statementlist, :$outer-frame, :$static-lexpad);
+            my $val = Val::Func.new(:$name, :$parameterlist, :$statementlist, :$outer-frame, :$static-lexpad);
             $<identifier>.ast.put-value($val, $*runtime);
         }
         finish-block($block);
@@ -683,7 +683,7 @@ class _007::Parser::Actions {
         my $identifier = $<identifier>
             ?? Q::Identifier.new(:$name)
             !! NONE;
-        make Q::Term::Sub.new(:$identifier, :$traitlist, :$block);
+        make Q::Term::Func.new(:$identifier, :$traitlist, :$block);
     }
 
     method unquote ($/) {
@@ -762,7 +762,7 @@ class _007::Parser::Actions {
         my $name = $<identifier>.ast.name;
         my $identifier = Q::Identifier.new(:$name);
         make Q::Property.new(:key($name), :value(
-            Q::Term::Sub.new(:$identifier, :$block)));
+            Q::Term::Func.new(:$identifier, :$block)));
         finish-block($block);
     }
 
@@ -891,19 +891,19 @@ sub check(Q::Block $ast, $runtime) is export {
         $runtime.leave();
     }
 
-    multi handle(Q::Statement::Sub $sub) {
+    multi handle(Q::Statement::Func $func) {
         my $outer-frame = $runtime.current-frame;
-        my $name = $sub.identifier.name;
-        my $val = Val::Sub.new(:$name,
-            :parameterlist($sub.block.parameterlist),
-            :statementlist($sub.block.statementlist),
+        my $name = $func.identifier.name;
+        my $val = Val::Func.new(:$name,
+            :parameterlist($func.block.parameterlist),
+            :statementlist($func.block.statementlist),
             :$outer-frame
         );
-        $runtime.enter($outer-frame, Val::Object.new, $sub.block.statementlist, $val);
-        handle($sub.block);
+        $runtime.enter($outer-frame, Val::Object.new, $func.block.statementlist, $val);
+        handle($func.block);
         $runtime.leave();
 
-        $runtime.declare-var($sub.identifier, $val);
+        $runtime.declare-var($func.identifier, $val);
     }
 
     multi handle(Q::Statement::Macro $macro) {

--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -68,12 +68,12 @@ grammar _007::Parser::Syntax {
         <EXPR>
     }
     token statement:block { <pblock> }
-    rule statement:sub-or-macro {
-        $<routine>=(sub|macro)» [<identifier> || <.panic("identifier")>]
-        :my $*insub = True;
+    rule statement:func-or-macro {
+        $<routine>=(func|macro)» [<identifier> || <.panic("identifier")>]
+        :my $*in_routine = True;
         {
-            declare($<routine> eq "sub"
-                        ?? Q::Statement::Sub
+            declare($<routine> eq "func"
+                        ?? Q::Statement::Func
                         !! Q::Statement::Macro,
                     $<identifier>.ast.name.value);
         }
@@ -256,13 +256,13 @@ grammar _007::Parser::Syntax {
     token term:identifier {
         <identifier>
     }
-    token term:sub {
-        sub <.ws> <identifier>?
-        :my $*insub = True;
+    token term:func {
+        func <.ws> <identifier>?
+        :my $*in_routine = True;
         <.newpad>
         {
             if $<identifier> {
-                declare(Q::Term::Sub, $<identifier>.ast.name.value);
+                declare(Q::Term::Func, $<identifier>.ast.name.value);
             }
         }
         '(' ~ ')' <parameterlist>
@@ -287,7 +287,7 @@ grammar _007::Parser::Syntax {
     rule property:method {
         <identifier>
         '(' ~ ')' [
-            :my $*insub = True;
+            :my $*in_routine = True;
             <.newpad>
             <parameterlist>
         ]

--- a/lib/_007/Q.pm
+++ b/lib/_007/Q.pm
@@ -353,11 +353,11 @@ class Q::TraitList does Q {
     method attribute-order { <traits> }
 }
 
-### ### Q::Term::Sub
+### ### Q::Term::Func
 ###
 ### A subroutine.
 ###
-class Q::Term::Sub does Q::Term does Q::Declaration {
+class Q::Term::Func does Q::Term does Q::Declaration {
     has $.identifier;
     has $.traitlist = Q::TraitList.new;
     has $.block;
@@ -368,7 +368,7 @@ class Q::Term::Sub does Q::Term does Q::Declaration {
         my $name = $.identifier ~~ Val::NoneType
             ?? Val::Str.new(:value(""))
             !! $.identifier.name;
-        return Val::Sub.new(
+        return Val::Func.new(
             :$name,
             :parameterlist($.block.parameterlist),
             :statementlist($.block.statementlist),
@@ -664,7 +664,7 @@ class Q::Postfix::Index is Q::Postfix {
                     if $index.value < 0;
                 return .elements[$index.value];
             }
-            when Val::Object | Val::Sub | Q {
+            when Val::Object | Val::Func | Q {
                 my $property = $.index.eval($runtime);
                 die X::Subscript::NonString.new
                     if $property !~~ Val::Str;
@@ -713,7 +713,7 @@ class Q::Postfix::Call is Q::Postfix {
         die "macro is called at runtime"
             if $c ~~ Val::Macro;
         die "Trying to invoke a {$c.^name.subst(/^'Val::'/, '')}" # XXX: make this into an X::
-            unless $c ~~ Val::Sub;
+            unless $c ~~ Val::Func;
         my @arguments = $.argumentlist.arguments.elements.map(*.eval($runtime));
         return $runtime.call($c, @arguments);
     }
@@ -1078,11 +1078,11 @@ class Q::Statement::Throw does Q::Statement {
     }
 }
 
-### ### Q::Statement::Sub
+### ### Q::Statement::Func
 ###
 ### A subroutine declaration statement.
 ###
-class Q::Statement::Sub does Q::Statement does Q::Declaration {
+class Q::Statement::Func does Q::Statement does Q::Declaration {
     has $.identifier;
     has $.traitlist = Q::TraitList.new;
     has Q::Block $.block;

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -41,13 +41,13 @@ class _007::Runtime {
             self.declare-var($identifier, $value);
         }
         for $statementlist.statements.elements.kv -> $i, $_ {
-            when Q::Statement::Sub {
+            when Q::Statement::Func {
                 my $name = .identifier.name;
                 my $parameterlist = .block.parameterlist;
                 my $statementlist = .block.statementlist;
                 my $static-lexpad = .block.static-lexpad;
                 my $outer-frame = $frame;
-                my $val = Val::Sub.new(
+                my $val = Val::Func.new(
                     :$name,
                     :$parameterlist,
                     :$statementlist,
@@ -148,7 +148,7 @@ class _007::Runtime {
         }
     }
 
-    method call(Val::Sub $c, @arguments) {
+    method call(Val::Func $c, @arguments) {
         my $paramcount = $c.parameterlist.parameters.elements.elems;
         my $argcount = @arguments.elems;
         die X::ParameterMismatch.new(:type<Sub>, :$paramcount, :$argcount)
@@ -182,7 +182,7 @@ class _007::Runtime {
             my @elements = &fn.signature.params».name».&ditch-sigil».&parameter;
             my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
             my $statementlist = Q::StatementList.new();
-            return Val::Sub.new-builtin(&fn, $name, $parameterlist, $statementlist);
+            return Val::Func.new-builtin(&fn, $name, $parameterlist, $statementlist);
         }
 
         my $type = Val::Type.of($obj.WHAT).name;
@@ -419,7 +419,7 @@ class _007::Runtime {
                 $obj.create($properties.elements.map({ .elements[0].value => .elements[1] }));
             });
         }
-        elsif $obj ~~ Val::Sub && $propname eq any <outer-frame static-lexpad parameterlist statementlist> {
+        elsif $obj ~~ Val::Func && $propname eq any <outer-frame static-lexpad parameterlist statementlist> {
             return $obj."$propname"();
         }
         elsif $obj ~~ (Q | Val::Object) && ($obj.properties{$propname} :exists) {

--- a/lib/_007/Test.pm
+++ b/lib/_007/Test.pm
@@ -18,7 +18,7 @@ sub read(Str $ast) is export {
         array          => Q::Term::Array,
         object         => Q::Term::Object,
         regex          => Q::Term::Regex,
-        sub            => Q::Term::Sub,
+        func           => Q::Term::Func,
         quasi          => Q::Term::Quasi,
 
         'prefix:~'     => Q::Prefix::Str,
@@ -52,7 +52,7 @@ sub read(Str $ast) is export {
         stexpr         => Q::Statement::Expr,
         if             => Q::Statement::If,
         stblock        => Q::Statement::Block,
-        stsub          => Q::Statement::Sub,
+        stfunc         => Q::Statement::Func,
         macro          => Q::Statement::Macro,
         return         => Q::Statement::Return,
         for            => Q::Statement::For,

--- a/lib/_007/Val.pm
+++ b/lib/_007/Val.pm
@@ -32,7 +32,7 @@ role Val {
 ### It is also the value returned from a subroutine that didn't explicitly
 ### return a value:
 ###
-###     sub noreturn() {
+###     func noreturn() {
 ###     }
 ###     say(noreturn());    # --> `None`
 ###
@@ -78,7 +78,7 @@ constant NONE is export = Val::NoneType.new;
 ### or `while` loops. *Any* value can be used, and there's always a way
 ### for each type to convert any of its values to a boolean value:
 ###
-###     sub check(value) {
+###     func check(value) {
 ###         if value {
 ###             say("truthy");
 ###         }
@@ -341,8 +341,8 @@ class Val::Regex does Val {
 ### through a predicate function:
 ###
 ###     my numbers = [1, 2, 3, 4, 5];
-###     say(numbers.map(sub (e) { return e * 2 }));     # --> `[2, 4, 6, 8, 10]`
-###     say(numbers.filter(sub (e) { return e %% 2 })); # --> `[2, 4]`
+###     say(numbers.map(func (e) { return e * 2 }));     # --> `[2, 4, 6, 8, 10]`
+###     say(numbers.filter(func (e) { return e %% 2 })); # --> `[2, 4]`
 ###
 class Val::Array does Val {
     has @.elements;
@@ -378,7 +378,7 @@ our $global-object-id = 0;
 ###     say(o1 == o3);              # --> `True`
 ###
 ###     my o4 = {
-###         greet: sub () {
+###         greet: func () {
 ###             return "hi!";
 ###         }
 ###     };
@@ -558,25 +558,25 @@ class Val::Type does Val {
     }
 }
 
-### ### Sub
+### ### Func
 ###
-### A subroutine. When you define a subroutine in 007, the value of the
-### name bound is a `Sub` object.
+### A function. When you define a function in 007, the value of the
+### name bound is a `Func` object.
 ###
-###     sub agent() {
+###     func agent() {
 ###         return "Bond";
 ###     }
-###     say(agent);             # --> `<sub agent()>`
+###     say(agent);             # --> `<func agent()>`
 ###
 ### Subroutines are mostly distinguished by being *callable*, that is, they
 ### can be called at runtime by passing some values into them.
 ###
-###     sub add(x, y) {
+###     func add(x, y) {
 ###         return x + y;
 ###     }
 ###     say(add(2, 5));         # --> `7`
 ###
-class Val::Sub is Val {
+class Val::Func is Val {
     has Val::Str $.name;
     has &.hook = Callable;
     has $.parameterlist;
@@ -608,7 +608,7 @@ class Val::Sub is Val {
         sprintf "(%s)", $.parameterlist.parameters.elements».identifier».name.join(", ");
     }
 
-    method Str { "<sub {$.escaped-name}{$.pretty-parameters}>" }
+    method Str { "<func {$.escaped-name}{$.pretty-parameters}>" }
 }
 
 ### ### Macro
@@ -621,7 +621,7 @@ class Val::Sub is Val {
 ###     }
 ###     say(agent);             # --> `<macro agent()>`
 ###
-class Val::Macro is Val::Sub {
+class Val::Macro is Val::Func {
     method Str { "<macro {$.escaped-name}{$.pretty-parameters}>" }
 }
 
@@ -645,7 +645,7 @@ class Helper {
         when Val::Object { .quoted-Str }
         when Val::Type { "<type {.name}>" }
         when Val::Macro { "<macro {.escaped-name}{.pretty-parameters}>" }
-        when Val::Sub { "<sub {.escaped-name}{.pretty-parameters}>" }
+        when Val::Func { "<sub {.escaped-name}{.pretty-parameters}>" }
         when Val::Exception { "Exception \{message: {.message.quoted-Str}\}" }
         default {
             my $self = $_;

--- a/self-host/runtime.007
+++ b/self-host/runtime.007
@@ -15,7 +15,7 @@ constant NO_OUTER = {};
 my Runtime = {
     new() {
         my frames = [];
-        sub enter(outer_frame, static_lexpad) {
+        func enter(outer_frame, static_lexpad) {
             my frame = { outer_frame, pad: {} };
             frames.push(frame);
             for static_lexpad.keys() -> name {
@@ -24,17 +24,17 @@ my Runtime = {
                 declare_var(identifier, value);
             }
         }
-        sub leave() {
+        func leave() {
             frames.pop();
         }
-        sub current_frame() {
+        func current_frame() {
             if !frames {
                 return NO_OUTER;
             }
             return frames[frames.size() - 1];
         }
 
-        sub find_pad(symbol) {
+        func find_pad(symbol) {
             my frame = current_frame();
             # The below check didn't work
             # while frame.id != NO_OUTER.id {
@@ -47,15 +47,15 @@ my Runtime = {
             }
             throw new Exception { message: "Cannot find variable '" ~ symbol ~ "'" };
         }
-        sub get_var(name) {
+        func get_var(name) {
             my pad = find_pad(name);
             return pad[name];
         }
-        sub put_var(name, value) {
+        func put_var(name, value) {
             my pad = find_pad(name);
             pad[name] = value;
         }
-        sub declare_var(identifier, value) {
+        func declare_var(identifier, value) {
             my name = identifier.name;
             # XXX: don't know if we should expose identifier.frame in 007
             # my frame = identifier.frame || current_frame();
@@ -63,7 +63,7 @@ my Runtime = {
             frame.pad[name] = value;
         }
 
-        sub sigbind(c, arguments) {
+        func sigbind(c, arguments) {
             my paramcount = c.parameterlist.parameters.size();
             my argcount = arguments.size();
             if paramcount != argcount {
@@ -77,7 +77,7 @@ my Runtime = {
             }
         }
 
-        sub call(c, arguments) {
+        func call(c, arguments) {
             sigbind(c, arguments);
             my frame = current_frame();
             run(c.statementlist);
@@ -158,7 +158,7 @@ my Runtime = {
                 if c ~~ Macro {
                     throw new Exception { message: "macro is called at runtime" };
                 }
-                if c !~~ Sub {
+                if c !~~ Func {
                     throw new Exception { message: "Trying to invoke a " ~ type(c).name };
                 }
                 my arguments = op.argumentlist.arguments.map(eval);
@@ -185,9 +185,9 @@ my Runtime = {
             Q::Term::Array(array) {
                 return array.elements.map(eval);
             },
-            Q::Term::Sub(term) {
+            Q::Term::Func(term) {
                 my name = term.identifier && term.identifier.name || "";
-                return new Sub {
+                return new Func {
                     name,
                     parameterlist: term.block.parameterlist,
                     statementlist: term.block.statementlist,
@@ -213,7 +213,7 @@ my Runtime = {
             Q::Expr::BlockAdapter(adapter) {
             },
         };
-        sub eval(q) { return eval_of_type[type(q).name](q); }
+        func eval(q) { return eval_of_type[type(q).name](q); }
 
         my run_of_type = {
             Q::Statement::BEGIN(stmt) {
@@ -269,7 +269,7 @@ my Runtime = {
                     put_var(name, eval(stmt.expr));
                 }
             },
-            Q::Statement::Sub(stmt) {
+            Q::Statement::Func(stmt) {
                 # no runtime behavior
             },
             Q::Statement::While(stmt) {
@@ -295,7 +295,7 @@ my Runtime = {
             Q::Statement::Return(stmt) {
             },
         };
-        sub run(q) { run_of_type[type(q).name](q); }
+        func run(q) { run_of_type[type(q).name](q); }
 
         return { run, get_var, put_var };
     }

--- a/t/features/begin.t
+++ b/t/features/begin.t
@@ -97,7 +97,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f() {
+        func f() {
             my k;
             BEGIN {
                 k = 2;
@@ -111,7 +111,7 @@ use _007::Test;
     outputs
         $program,
         "2\n",
-        "...same, but inside a sub";
+        "...same, but inside a func";
 }
 
 {
@@ -185,7 +185,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub foo() {
+        func foo() {
             say(7);
         }
 
@@ -195,7 +195,7 @@ use _007::Test;
     outputs
         $program,
         "7\n",
-        "calling a sub at BEGIN time works";
+        "calling a func at BEGIN time works";
 }
 
 done-testing;

--- a/t/features/builtins/methods.t
+++ b/t/features/builtins/methods.t
@@ -212,7 +212,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist (param (identifier "n"))) (statementlist
+          (stfunc (identifier "f") (block (parameterlist (param (identifier "n"))) (statementlist
               (return (infix:== (identifier "n") (int 2))))))
           (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (postfix:. (array (int 1) (int 2) (int 3) (int 2)) (identifier "filter")) (argumentlist (identifier "f")))))))
         .
@@ -223,7 +223,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist (param (identifier "n"))) (statementlist
+          (stfunc (identifier "f") (block (parameterlist (param (identifier "n"))) (statementlist
               (return (infix:+ (identifier "n") (int 1))))))
           (my (identifier "a") (array (int 1) (int 2) (int 3)))
           (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (postfix:. (identifier "a") (identifier "map")) (argumentlist (identifier "f"))))))

--- a/t/features/builtins/operators.t
+++ b/t/features/builtins/operators.t
@@ -360,30 +360,30 @@ use _007::Test;
 }
 
 {
-    outputs 'sub foo() {}; say(foo == foo)', "True\n", "a sub is equal to itself";
+    outputs 'func foo() {}; say(foo == foo)', "True\n", "a func is equal to itself";
     outputs 'macro foo() {}; say(foo == foo)', "True\n", "a macro is equal to itself";
-    outputs 'say(say == say)', "True\n", "a built-in sub is equal to itself";
+    outputs 'say(say == say)', "True\n", "a built-in func is equal to itself";
     outputs 'say(infix:<+> == infix:<+>)', "True\n", "a built-in operator is equal to itself";
     outputs 'say(new Q::Identifier { name: "foo" } == new Q::Identifier { name: "foo" })', "True\n",
         "two Qtrees with equal content are equal";
-    outputs 'my a = []; for [1, 2] { sub fn() {}; a = [fn, a] }; say(a[1][0] == a[0])',
-        "True\n", "the same sub from two different frames compares favorably to itself";
-    outputs 'sub foo() {}; my x = foo; { sub foo() {}; say(x == foo) }', "True\n",
-        "subs with the same name and bodies are equal (I)";
-    outputs 'sub foo() { say("OH HAI") }; my x = foo; { sub foo() { say("OH HAI") }; say(x == foo) }',
-        "True\n", "subs with the same name and bodies are equal (II)";
+    outputs 'my a = []; for [1, 2] { func fn() {}; a = [fn, a] }; say(a[1][0] == a[0])',
+        "True\n", "the same func from two different frames compares favorably to itself";
+    outputs 'func foo() {}; my x = foo; { func foo() {}; say(x == foo) }', "True\n",
+        "funcs with the same name and bodies are equal (I)";
+    outputs 'func foo() { say("OH HAI") }; my x = foo; { func foo() { say("OH HAI") }; say(x == foo) }',
+        "True\n", "funcs with the same name and bodies are equal (II)";
 
-    outputs 'sub foo() {}; sub bar() {}; say(foo == bar)', "False\n",
-        "distinct subs are unequal";
+    outputs 'func foo() {}; func bar() {}; say(foo == bar)', "False\n",
+        "distinct funcs are unequal";
     outputs 'macro foo() {}; macro bar() {}; say(foo == bar)', "False\n",
         "distinct macros are unequal";
-    outputs 'say(say == type)', "False\n", "distinct built-in subs are unequal";
+    outputs 'say(say == type)', "False\n", "distinct built-in funcs are unequal";
     outputs 'say(infix:<+> == prefix:<->)', "False\n",
         "distinct built-in operators are unequal";
-    outputs 'sub foo(y) {}; my x = foo; { sub foo(x) {}; say(x == foo) }', "False\n",
-        "subs with different parameters are unequal";
-    outputs 'sub foo() {}; my x = foo; { sub foo() { say("OH HAI") }; say(x == foo) }', "False\n",
-        "subs with different bodies are unequal";
+    outputs 'func foo(y) {}; my x = foo; { func foo(x) {}; say(x == foo) }', "False\n",
+        "funcs with different parameters are unequal";
+    outputs 'func foo() {}; my x = foo; { func foo() { say("OH HAI") }; say(x == foo) }', "False\n",
+        "funcs with different bodies are unequal";
     outputs 'say(new Q::Identifier { name: "foo" } == new Q::Identifier { name: "bar" })', "False\n",
         "two Qtrees with distinct content are unequal";
 }
@@ -408,7 +408,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "empty") (block (parameterlist) (statementlist)))
+          (stfunc (identifier "empty") (block (parameterlist) (statementlist)))
           (my (identifier "none") (postfix:() (identifier "empty") (argumentlist)))
           (stexpr (postfix:() (identifier "say") (argumentlist (infix:== (identifier "none") (identifier "none")))))
           (stexpr (postfix:() (identifier "say") (argumentlist (infix:== (identifier "none") (int 0)))))
@@ -490,7 +490,7 @@ use _007::Test;
 {
     my $program = q:to/./;
         my a = [1, 2, 3];
-        sub f() { return 7 };
+        func f() { return 7 };
         my o = { foo: 12 };
 
         say(-a[1]);
@@ -708,7 +708,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f() {
+        func f() {
             say("I never get run, you know");
         }
         say(007 // f());

--- a/t/features/builtins/subs.t
+++ b/t/features/builtins/subs.t
@@ -54,11 +54,11 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist)))
+          (stfunc (identifier "f") (block (parameterlist) (statementlist)))
           (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (identifier "type") (argumentlist (identifier "f")))))))
         .
 
-    is-result $ast, "<type Sub>\n", "sub type() works";
+    is-result $ast, "<type Func>\n", "func type() works";
 }
 
 {
@@ -67,7 +67,7 @@ use _007::Test;
           (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (identifier "type") (argumentlist (identifier "say")))))))
         .
 
-    is-result $ast, "<type Sub>\n", "builtin sub type() returns the same as ordinary sub";
+    is-result $ast, "<type Func>\n", "builtin func type() returns the same as ordinary func";
 }
 
 done-testing;

--- a/t/features/custom-ops.t
+++ b/t/features/custom-ops.t
@@ -4,13 +4,13 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<n>(left, right) {
+        func infix:<n>(left, right) {
         }
         .
 
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "infix:n") (block (parameterlist (param (identifier "left")) (param (identifier "right"))) (statementlist))))
+          (stfunc (identifier "infix:n") (block (parameterlist (param (identifier "left")) (param (identifier "right"))) (statementlist))))
         .
 
     parses-to $program, $ast, "custom operator parses to the right thing";
@@ -18,7 +18,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<n>(left, right) {
+        func infix:<n>(left, right) {
             return 20;
         }
 
@@ -39,7 +39,7 @@ use _007::Test;
 {
     my $program = q:to/./;
         {
-            sub infix:<n>(left, right) {
+            func infix:<n>(left, right) {
                 return 7;
             }
         }
@@ -51,7 +51,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<+>(left, right) {
+        func infix:<+>(left, right) {
             return 14;
         }
 
@@ -63,11 +63,11 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<~~>(left, right) {
+        func infix:<~~>(left, right) {
             return "wrong";
         }
 
-        sub infix:<~~~>(left, right) {
+        func infix:<~~~>(left, right) {
             return "right";
         }
 
@@ -79,11 +79,11 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<***>(left, right) {
+        func infix:<***>(left, right) {
             return "right";
         }
 
-        sub infix:<**>(left, right) {
+        func infix:<**>(left, right) {
             return "wrong";
         }
 
@@ -95,7 +95,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<!>(left, right) {
+        func infix:<!>(left, right) {
             say(left ~ " " ~ right);
         }
 
@@ -107,7 +107,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<*!>(left, right) {
+        func infix:<*!>(left, right) {
             return 10;
         }
 
@@ -119,7 +119,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<~?>(left, right) is looser(infix:<+>) {
+        func infix:<~?>(left, right) is looser(infix:<+>) {
             return 6;
         }
 
@@ -131,7 +131,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<~?>(left, right) is tighter(infix:<+>) {
+        func infix:<~?>(left, right) is tighter(infix:<+>) {
             return 6;
         }
 
@@ -143,11 +143,11 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<*>(left, right) {
+        func infix:<*>(left, right) {
             return 18;
         }
 
-        sub infix:<~@>(left, right) is tighter(infix:<+>) {
+        func infix:<~@>(left, right) is tighter(infix:<+>) {
             return 30;
         }
 
@@ -159,7 +159,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<!?!>(left, right) is tighter(infix:<+>) is looser(infix:<+>) {
+        func infix:<!?!>(left, right) is tighter(infix:<+>) is looser(infix:<+>) {
         }
         .
 
@@ -168,7 +168,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<!?!>(left, right) is equal(infix:<+>) is equal(infix:<*>) {
+        func infix:<!?!>(left, right) is equal(infix:<+>) is equal(infix:<*>) {
         }
         .
 
@@ -178,11 +178,11 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<@>(left, right) {
+        func infix:<@>(left, right) {
             return "@";
         }
 
-        sub infix:<!>(left, right) is equal(infix:<@>) {
+        func infix:<!>(left, right) is equal(infix:<@>) {
             return "!";
         }
 
@@ -195,7 +195,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<!?!>(left, right) is tighter(infix:<+>) is equal(infix:<+>) {
+        func infix:<!?!>(left, right) is tighter(infix:<+>) is equal(infix:<+>) {
         }
         .
 
@@ -204,7 +204,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<!++>(left, right) is looser(infix:<+>) is equal(infix:<+>) {
+        func infix:<!++>(left, right) is looser(infix:<+>) is equal(infix:<+>) {
         }
         .
 
@@ -213,7 +213,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<@>(left, right) is assoc("right") {
+        func infix:<@>(left, right) is assoc("right") {
             return "(" ~ left ~ ", " ~ right ~ ")";
         }
 
@@ -225,7 +225,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<%>(left, right) is assoc("left") {
+        func infix:<%>(left, right) is assoc("left") {
             return "(" ~ left ~ ", " ~ right ~ ")";
         }
 
@@ -237,7 +237,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:</>(left, right) {
+        func infix:</>(left, right) {
             return "(" ~ left ~ ", " ~ right ~ ")";
         }
 
@@ -249,7 +249,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<!>(left, right) is assoc("non") {
+        func infix:<!>(left, right) is assoc("non") {
             return "oh, James";
         }
 
@@ -261,7 +261,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<!>(left, right) is assoc("non") {
+        func infix:<!>(left, right) is assoc("non") {
             return "oh, James";
         }
 
@@ -273,7 +273,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<&-&>(left, right) is assoc("salamander") {
+        func infix:<&-&>(left, right) is assoc("salamander") {
         }
         .
 
@@ -282,10 +282,10 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<@>(left, right) is assoc("right") {
+        func infix:<@>(left, right) is assoc("right") {
         }
 
-        sub infix:<@@>(left, right) is equal(infix:<@>) {
+        func infix:<@@>(left, right) is equal(infix:<@>) {
             return "(" ~ left ~ ", " ~ right ~ ")";
         }
 
@@ -297,10 +297,10 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<@>(left, right) is assoc("non") {
+        func infix:<@>(left, right) is assoc("non") {
         }
 
-        sub infix:<@@>(left, right) is equal(infix:<@>) {
+        func infix:<@@>(left, right) is equal(infix:<@>) {
             return "(" ~ left ~ ", " ~ right ~ ")";
         }
 
@@ -312,10 +312,10 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<%>(left, right) is assoc("left") {
+        func infix:<%>(left, right) is assoc("left") {
         }
 
-        sub infix:<%%>(left, right) is equal(infix:<%>) is assoc("right") {
+        func infix:<%%>(left, right) is equal(infix:<%>) is assoc("right") {
         }
         .
 
@@ -325,7 +325,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub prefix:<¿>(term) {
+        func prefix:<¿>(term) {
             return 42;
         }
 
@@ -337,7 +337,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub postfix:<!>(term) {
+        func postfix:<!>(term) {
             return 1;
         }
 
@@ -349,19 +349,19 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub prefix:<¿>(term) {
+        func prefix:<¿>(term) {
             return "prefix is looser";
         }
 
-        sub postfix:<!>(term) {
+        func postfix:<!>(term) {
             return "postfix is looser";
         }
 
-        sub postfix:<$>(term) {
+        func postfix:<$>(term) {
             return "postfix is looser";
         }
 
-        sub prefix:<%>(term) {
+        func prefix:<%>(term) {
             return "prefix is looser";
         }
 
@@ -374,19 +374,19 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub prefix:<¿>(term) {
+        func prefix:<¿>(term) {
             return "prefix is looser";
         }
 
-        sub postfix:<!>(term) is looser(prefix:<¿>) {
+        func postfix:<!>(term) is looser(prefix:<¿>) {
             return "postfix is looser";
         }
 
-        sub postfix:<$>(term) {
+        func postfix:<$>(term) {
             return "postfix is looser";
         }
 
-        sub prefix:<%>(term) is tighter(postfix:<$>) {
+        func prefix:<%>(term) is tighter(postfix:<$>) {
             return "prefix is looser";
         }
 
@@ -399,19 +399,19 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub postfix:<!>(term) {
+        func postfix:<!>(term) {
             return "postfix is looser";
         }
 
-        sub prefix:<¿>(term) is tighter(postfix:<!>) {
+        func prefix:<¿>(term) is tighter(postfix:<!>) {
             return "prefix is looser";
         }
 
-        sub prefix:<%>(term) {
+        func prefix:<%>(term) {
             return "prefix is looser";
         }
 
-        sub postfix:<$>(term) is looser(prefix:<%>) {
+        func postfix:<$>(term) is looser(prefix:<%>) {
             return "postfix is looser";
         }
 
@@ -424,19 +424,19 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub postfix:<¡>(term) is assoc("right") {
+        func postfix:<¡>(term) is assoc("right") {
             return "postfix is looser";
         }
 
-        sub prefix:<¿>(term) is equal(postfix:<¡>) {
+        func prefix:<¿>(term) is equal(postfix:<¡>) {
             return "prefix is looser";
         }
 
-        sub prefix:<%>(term) is assoc("left") {
+        func prefix:<%>(term) is assoc("left") {
             return "prefix is looser";
         }
 
-        sub postfix:<$>(term) is equal(prefix:<%>) {
+        func postfix:<$>(term) is equal(prefix:<%>) {
             return "postfix is looser";
         }
 
@@ -450,10 +450,10 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub prefix:<¿>(left, right) is assoc("non") {
+        func prefix:<¿>(left, right) is assoc("non") {
         }
 
-        sub postfix:<!>(left, right) is equal(prefix:<¿>) {
+        func postfix:<!>(left, right) is equal(prefix:<¿>) {
         }
 
         say(¿0!);
@@ -464,7 +464,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub postfix:<!>(left, right) is tighter(infix:<+>) {
+        func postfix:<!>(left, right) is tighter(infix:<+>) {
         }
         .
 
@@ -473,7 +473,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<!>(left, right) is tighter(prefix:<->) {
+        func infix:<!>(left, right) is tighter(prefix:<->) {
         }
         .
 
@@ -482,7 +482,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:«!»(l, r) {
+        func infix:«!»(l, r) {
             return "Mr. Bond";
         }
 
@@ -494,7 +494,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:<\>>(l, r) {
+        func infix:<\>>(l, r) {
             return "James";
         }
 
@@ -506,11 +506,11 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub postfix:<‡>(x) is looser(prefix:<^>) {
+        func postfix:<‡>(x) is looser(prefix:<^>) {
             return [];
         }
 
-        sub prefix:<$>(x) {
+        func prefix:<$>(x) {
             return x.size();
         }
 
@@ -522,16 +522,16 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub prefix:<&>(x) {
+        func prefix:<&>(x) {
             return x ~ " prefix:<&>";
         }
 
-        sub postfix:<‡>(x) is looser(prefix:<&>) {
+        func postfix:<‡>(x) is looser(prefix:<&>) {
             return x ~ " postfix:<‡>";
         }
 
         {
-            sub prefix:<$>(x) {
+            func prefix:<$>(x) {
                 return x ~ " prefix:<$>";
             }
 
@@ -544,15 +544,15 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub postfix:<&>(x) {
+        func postfix:<&>(x) {
             return 1;
         }
 
-        sub prefix:<&>(x) {
+        func prefix:<&>(x) {
             return 2;
         }
 
-        sub prefix:<@>(x) {
+        func prefix:<@>(x) {
             return 3;
         }
 
@@ -568,7 +568,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub infix:«->»(lhs, rhs) {
+        func infix:«->»(lhs, rhs) {
             return "Bond";
         }
 

--- a/t/features/if-statement.t
+++ b/t/features/if-statement.t
@@ -20,7 +20,7 @@ use _007::Test;
             (stexpr (postfix:() (identifier "say") (argumentlist (str "falsy array")))))))
           (if (array (str "")) (block (parameterlist) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (str "truthy array")))))))
-          (stsub (identifier "foo") (block (parameterlist) (statementlist)))
+          (stfunc (identifier "foo") (block (parameterlist) (statementlist)))
           (if (identifier "foo") (block (parameterlist) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (str "truthy sub")))))))
           (macro (identifier "bar") (block (parameterlist) (statementlist)))

--- a/t/features/objects.t
+++ b/t/features/objects.t
@@ -15,8 +15,8 @@ use _007::Test;
         '{a: 1}' '(object (identifier "Object") (propertylist (property "a" (int 1))))'
         '{a: 1 + 2}' '(object (identifier "Object") (propertylist (property "a" (infix:+ (int 1) (int 2)))))'
         '{a() {}}' '(object (identifier "Object") (propertylist
-          (property "a" (sub (identifier "a") (block (parameterlist) (statementlist))))))'
-        '{a(a, b) {}}' '(object (identifier "Object") (propertylist (property "a" (sub (identifier "a") (block
+          (property "a" (func (identifier "a") (block (parameterlist) (statementlist))))))'
+        '{a(a, b) {}}' '(object (identifier "Object") (propertylist (property "a" (func (identifier "a") (block
           (parameterlist (param (identifier "a")) (param (identifier "b"))) (statementlist))))))'
     »;
 
@@ -231,7 +231,7 @@ use _007::Test;
     my $ast = q:to/./;
         (statementlist
           (my (identifier "obj") (object (identifier "Object") (propertylist
-            (property "meth" (sub (identifier "meth") (block (parameterlist) (statementlist
+            (property "meth" (func (identifier "meth") (block (parameterlist) (statementlist
               (return (int 7))))))))))
         .
 
@@ -242,7 +242,7 @@ use _007::Test;
     my $program = q:to/./;
         f();
         my o = { say };
-        sub f() { say("Mr. Bond") }
+        func f() { say("Mr. Bond") }
         .
 
     outputs

--- a/t/features/q.t
+++ b/t/features/q.t
@@ -50,7 +50,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = new Q::Statement::Sub {
+        my q = new Q::Statement::Func {
             identifier: new Q::Identifier { name: "foo" },
             block: new Q::Block {
                 parameterlist: new Q::ParameterList { parameters: [] },

--- a/t/features/quasi.t
+++ b/t/features/quasi.t
@@ -45,7 +45,7 @@ use _007::Test;
 {
     my $program = q:to/./;
         macro moo() {
-            sub infix:<**>(l, r) {
+            func infix:<**>(l, r) {
                 return l ~ " to the " ~ r;
             }
             return quasi {
@@ -69,7 +69,7 @@ use _007::Test;
         }
 
         {
-            sub infix:<+>(l, r) { return "lol, pwnd!" }
+            func infix:<+>(l, r) { return "lol, pwnd!" }
             gah()
         }
         .
@@ -340,7 +340,7 @@ use _007::Test;
             }
         };
 
-        sub ignore(x) {}
+        func ignore(x) {}
 
         ignore(moo());
         .

--- a/t/features/return.t
+++ b/t/features/return.t
@@ -5,7 +5,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (return (int 7)))))
           (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (identifier "f") (argumentlist))))))
         .
@@ -16,7 +16,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (return (str "Bond. James Bond.")))))
           (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (identifier "f") (argumentlist))))))
         .
@@ -27,7 +27,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (return (array (int 1) (int 2) (str "three"))))))
           (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (identifier "f") (argumentlist))))))
         .
@@ -38,7 +38,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (return (int 1953))
             (stexpr (postfix:() (identifier "say") (argumentlist (str "Dead code. Should have returned by now.")))))))
           (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (identifier "f") (argumentlist))))))
@@ -50,7 +50,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (return))))
           (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (identifier "f") (argumentlist))))))
         .
@@ -61,7 +61,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (stexpr (int 7)))))
           (stexpr (postfix:() (identifier "say") (argumentlist (postfix:() (identifier "f") (argumentlist))))))
         .

--- a/t/features/stringification.t
+++ b/t/features/stringification.t
@@ -3,15 +3,15 @@ use Test;
 use _007::Test;
 
 {
-    outputs 'sub foo() {}; say(foo)', "<sub foo()>\n", "zero-param sub";
-    outputs 'sub fn(x, y, z) {}; say(fn)', "<sub fn(x, y, z)>\n", "sub with three parameters";
-    outputs 'say(say)', "<sub say(arg)>\n", "builtin sub";
-    outputs 'say(infix:<+>)', "<sub infix:<+>(lhs, rhs)>\n", "builtin sub (infix)";
-    outputs 'say(infix:<\>>)', "<sub infix:«>»(lhs, rhs)>\n", "builtin sub (infix) -- contains > (I)";
-    outputs 'say(infix:«>»)', "<sub infix:«>»(lhs, rhs)>\n", "builtin sub (infix) -- contains > (II)";
-    outputs 'sub infix:<\>»>(lhs, rhs) {}; say(infix:<\>»>)',
-        "<sub infix:<\>»>(lhs, rhs)>\n",
-        "builtin sub (infix) -- contains both > and »";
+    outputs 'func foo() {}; say(foo)', "<func foo()>\n", "zero-param sub";
+    outputs 'func fn(x, y, z) {}; say(fn)', "<func fn(x, y, z)>\n", "func with three parameters";
+    outputs 'say(say)', "<func say(arg)>\n", "builtin sub";
+    outputs 'say(infix:<+>)', "<func infix:<+>(lhs, rhs)>\n", "builtin func (infix)";
+    outputs 'say(infix:<\>>)', "<func infix:«>»(lhs, rhs)>\n", "builtin func (infix) -- contains > (I)";
+    outputs 'say(infix:«>»)', "<func infix:«>»(lhs, rhs)>\n", "builtin func (infix) -- contains > (II)";
+    outputs 'func infix:<\>»>(lhs, rhs) {}; say(infix:<\>»>)',
+        "<func infix:<\>»>(lhs, rhs)>\n",
+        "builtin func (infix) -- contains both > and »";
     outputs 'macro foo() {}; say(foo)', "<macro foo()>\n", "zero-param macro";
     outputs 'macro mc(x, y, z) {}; say(mc)', "<macro mc(x, y, z)>\n", "macro with three parameters";
 }

--- a/t/features/subs.t
+++ b/t/features/subs.t
@@ -5,7 +5,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (str "OH HAI from inside sub"))))))))
         .
 
@@ -17,7 +17,7 @@ use _007::Test;
         (statementlist
           (my (identifier "x") (str "one"))
           (stexpr (postfix:() (identifier "say") (argumentlist (identifier "x"))))
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (my (identifier "x") (str "two"))
             (stexpr (postfix:() (identifier "say") (argumentlist (identifier "x")))))))
           (stexpr (postfix:() (identifier "f") (argumentlist)))
@@ -30,18 +30,18 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist (param (identifier "name"))) (statementlist
+          (stfunc (identifier "f") (block (parameterlist (param (identifier "name"))) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (infix:~ (str "Good evening, Mr ") (identifier "name"))))))))
           (stexpr (postfix:() (identifier "f") (argumentlist (str "Bond")))))
         .
 
-    is-result $ast, "Good evening, Mr Bond\n", "calling a sub with parameters works";
+    is-result $ast, "Good evening, Mr Bond\n", "calling a func with parameters works";
 }
 
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist (param (identifier "X")) (param (identifier "Y"))) (statementlist
+          (stfunc (identifier "f") (block (parameterlist (param (identifier "X")) (param (identifier "Y"))) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (infix:~ (identifier "X") (identifier "Y"))))))))
           (my (identifier "X") (str "y"))
           (stexpr (postfix:() (identifier "f") (argumentlist (str "X") (infix:~ (identifier "X") (identifier "X"))))))
@@ -52,12 +52,12 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f(callback) {
+        func f(callback) {
             my scoping = "dynamic";
             callback();
         }
         my scoping = "lexical";
-        f(sub() { say(scoping) });
+        f(func() { say(scoping) });
         .
 
     outputs $program, "lexical\n", "scoping is lexical";
@@ -67,11 +67,11 @@ use _007::Test;
     my $ast = q:to/./;
         (statementlist
           (stexpr (postfix:() (identifier "f") (argumentlist)))
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (str "OH HAI from inside sub"))))))))
         .
 
-    is-result $ast, "OH HAI from inside sub\n", "call a sub before declaring it";
+    is-result $ast, "OH HAI from inside sub\n", "call a func before declaring it";
 }
 
 {
@@ -79,17 +79,17 @@ use _007::Test;
         (statementlist
           (stexpr (postfix:() (identifier "f") (argumentlist)))
           (my (identifier "x") (str "X"))
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (identifier "x"))))))))
         .
 
-    is-result $ast, "None\n", "using an outer lexical in a sub that's called before the outer lexical's declaration";
+    is-result $ast, "None\n", "using an outer lexical in a func that's called before the outer lexical's declaration";
 }
 
 {
     my $program = q:to/./;
-        sub f() { say("OH HAI") }
-        sub g() { return f };
+        func f() { say("OH HAI") }
+        func g() { return f };
         g()();
         .
 
@@ -101,28 +101,28 @@ use _007::Test;
     my $ast = q:to/./;
         (statementlist
           (stexpr (postfix:() (identifier "f") (argumentlist (str "Bond"))))
-          (stsub (identifier "f") (block (parameterlist (param (identifier "name"))) (statementlist
+          (stfunc (identifier "f") (block (parameterlist (param (identifier "name"))) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (infix:~ (str "Good evening, Mr ") (identifier "name")))))))))
         .
 
-    is-result $ast, "Good evening, Mr Bond\n", "calling a post-declared sub works (I)";
+    is-result $ast, "Good evening, Mr Bond\n", "calling a post-declared func works (I)";
 }
 
 {
-    my $program = 'f("Bond"); sub f(name) { say("Good evening, Mr " ~ name) }';
+    my $program = 'f("Bond"); func f(name) { say("Good evening, Mr " ~ name) }';
 
-    outputs $program, "Good evening, Mr Bond\n", "calling a post-declared sub works (II)";
+    outputs $program, "Good evening, Mr Bond\n", "calling a post-declared func works (II)";
 }
 
 {
-    my $program = 'my b = 42; sub g() { say(b) }; g()';
+    my $program = 'my b = 42; func g() { say(b) }; g()';
 
     outputs $program, "42\n", "lexical scope works correctly from inside a sub";
 }
 
 {
     my $program = q:to/./;
-        sub f() {}
+        func f() {}
         f = 5;
         .
 
@@ -134,8 +134,8 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f() {}
-        sub h(a, b, f) {
+        func f() {}
+        func h(a, b, f) {
             f = 17;
             say(f == 17);
         }
@@ -150,7 +150,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my f = sub (x) { say(x) };
+        my f = func (x) { say(x) };
         f("Mr Bond");
         .
 
@@ -161,7 +161,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my f = sub g(x) { say(x) };
+        my f = func g(x) { say(x) };
         f("Mr Bond");
         .
 
@@ -172,29 +172,29 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my f = sub g(x) {};
+        my f = func g(x) {};
         say(f);
         .
 
     outputs $program,
-        "<sub g(x)>\n",
+        "<func g(x)>\n",
         "...and they know their own name";
 }
 
 {
     my $program = q:to/./;
-        my f = sub g() { say(g) };
+        my f = func g() { say(g) };
         f();
         .
 
     outputs $program,
-        "<sub g()>\n",
-        "the name of a sub is visible inside the sub...";
+        "<func g()>\n",
+        "the name of a func is visible inside the sub...";
 }
 
 {
     my $program = q:to/./;
-        my f = sub g() {};
+        my f = func g() {};
         g();
         .
 
@@ -205,7 +205,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my f = sub () {
+        my f = func () {
             my c = "Goldfinger";
             say(c);
         };
@@ -220,8 +220,8 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f(x,) { }
-        sub g(x,y,) { }
+        func f(x,) { }
+        func g(x,y,) { }
         .
 
     outputs $program, "", "trailing commas are allowed in parameterlist";
@@ -229,8 +229,8 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f(x)   { say(1) }
-        sub g(x,y) { say(2) }
+        func f(x)   { say(1) }
+        func g(x,y) { say(2) }
         f(4,);
         g(4,5,);
         .
@@ -239,14 +239,14 @@ use _007::Test;
 }
 
 {
-    my $program = 'sub subtract(x) { say(x) }; subtract("Mr Bond")';
+    my $program = 'func subtract(x) { say(x) }; subtract("Mr Bond")';
 
-    outputs $program, "Mr Bond\n", "it's OK to call your sub 'subtract'";
+    outputs $program, "Mr Bond\n", "it's OK to call your func 'subtract'";
 }
 
 {
     my $program = q:to/./;
-        sub fn()
+        func fn()
         .
 
     my subset missing-block of X::Syntax::Missing where {
@@ -261,7 +261,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub b(count) {
+        func b(count) {
             if count {
                 b(count - 1);
                 say(count);
@@ -270,15 +270,15 @@ use _007::Test;
         b(4);
         .
 
-    outputs $program, "1\n2\n3\n4\n", "each sub invocation gets its own callframe/scope";
+    outputs $program, "1\n2\n3\n4\n", "each func invocation gets its own callframe/scope";
 }
 
 {
     my $program = q:to/./;
-        say(sub () {});
+        say(func () {});
         .
 
-    outputs $program, "<sub ()>\n", "an anonymous sub stringifies without a name";
+    outputs $program, "<func ()>\n", "an anonymous func stringifies without a name";
 }
 
 done-testing;

--- a/t/features/syntax-elements.t
+++ b/t/features/syntax-elements.t
@@ -213,14 +213,14 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f() {
+        func f() {
             say("sub");
         }
         .
 
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (str "sub"))))))))
         .
 
@@ -229,46 +229,46 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f(name) {
+        func f(name) {
             say("Mr " ~ name);
         }
         .
 
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist (param (identifier "name"))) (statementlist
+          (stfunc (identifier "f") (block (parameterlist (param (identifier "name"))) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (infix:~ (str "Mr ") (identifier "name")))))))))
         .
 
-    parses-to $program, $ast, "sub with parameter";
+    parses-to $program, $ast, "func with parameter";
 }
 
 {
     my $program = q:to/./;
-        sub f(X, Y) {
+        func f(X, Y) {
             say(X ~ Y);
         }
         .
 
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist (param (identifier "X")) (param (identifier "Y"))) (statementlist
+          (stfunc (identifier "f") (block (parameterlist (param (identifier "X")) (param (identifier "Y"))) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (infix:~ (identifier "X") (identifier "Y")))))))))
         .
 
-    parses-to $program, $ast, "sub with two parameters";
+    parses-to $program, $ast, "func with two parameters";
 }
 
 {
     my $program = q:to/./;
-        sub f() {
+        func f() {
             return 7;
         }
         .
 
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (return (int 7))))))
         .
 
@@ -277,14 +277,14 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f() {
+        func f() {
             return;
         }
         .
 
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (return)))))
         .
 
@@ -293,11 +293,11 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f() {
+        func f() {
             say("OH HAI");
         }
-        sub g() {
-            sub h() { f() };
+        func g() {
+            func h() { f() };
             return h;
         }
         g()();
@@ -305,10 +305,10 @@ use _007::Test;
 
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "f") (block (parameterlist) (statementlist
+          (stfunc (identifier "f") (block (parameterlist) (statementlist
             (stexpr (postfix:() (identifier "say") (argumentlist (str "OH HAI")))))))
-          (stsub (identifier "g") (block (parameterlist) (statementlist
-            (stsub (identifier "h") (block (parameterlist) (statementlist
+          (stfunc (identifier "g") (block (parameterlist) (statementlist
+            (stfunc (identifier "h") (block (parameterlist) (statementlist
               (stexpr (postfix:() (identifier "f") (argumentlist))))))
             (return (identifier "h")))))
           (stexpr (postfix:() (postfix:() (identifier "g") (argumentlist)) (argumentlist))))

--- a/t/features/unquote.t
+++ b/t/features/unquote.t
@@ -122,7 +122,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub foo(a, b, c) {
+        func foo(a, b, c) {
             say(a);
             say(b);
             say(c);

--- a/t/integration/corner-cases.t
+++ b/t/integration/corner-cases.t
@@ -137,7 +137,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f(X, Y, X) {
+        func f(X, Y, X) {
             say(X ~ Y);
         }
         .
@@ -168,7 +168,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub foo(x) {
+        func foo(x) {
             my x;
         }
         .
@@ -228,11 +228,11 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub f() {}
+        func f() {}
         my f;
         .
 
-    parse-error $program, X::Redeclaration, "can't have a sub and a variable sharing a name";
+    parse-error $program, X::Redeclaration, "can't have a func and a variable sharing a name";
 }
 
 {
@@ -240,7 +240,7 @@ use _007::Test;
         my f;
         {
             f = 3;
-            sub f() {
+            func f() {
             }
         }
         .
@@ -271,7 +271,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub !() {}
+        func !() {}
         .
 
     parse-error $program, X::Syntax::Missing, "must have a valid identifier after `sub`";
@@ -330,18 +330,18 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub j(t) { for t -> x {} }
+        func j(t) { for t -> x {} }
         my t;
         .
 
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "j") (block (parameterlist (param (identifier "t"))) (statementlist
+          (stfunc (identifier "j") (block (parameterlist (param (identifier "t"))) (statementlist
             (for (identifier "t") (block (parameterlist (param (identifier "x"))) (statementlist))))))
           (my (identifier "t")))
         .
 
-    parses-to $program, $ast, "a var outside a sub does not collide with a param inside used in a for loop";
+    parses-to $program, $ast, "a var outside a func does not collide with a param inside used in a for loop";
 }
 
 done-testing;

--- a/t/integration/fibonacci.t
+++ b/t/integration/fibonacci.t
@@ -5,7 +5,7 @@ use _007::Test;
 {
     my $ast = q:to/./;
         (statementlist
-          (stsub (identifier "fib") (block (parameterlist (param (identifier "n"))) (statementlist
+          (stfunc (identifier "fib") (block (parameterlist (param (identifier "n"))) (statementlist
             (if (infix:== (identifier "n") (int 0)) (block (parameterlist) (statementlist
               (return (int 1)))))
             (if (infix:== (identifier "n") (int 1)) (block (parameterlist) (statementlist

--- a/t/integration/man-or-boy.t
+++ b/t/integration/man-or-boy.t
@@ -4,11 +4,11 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        sub A(k, x1, x2, x3, x4, x5) {
+        func A(k, x1, x2, x3, x4, x5) {
             if k <= 0 {
                 return x4() + x5();
             } else {
-                sub B() {
+                func B() {
                     k = k - 1;
                     return A(k, B, x1, x2, x3, x4);
                 }
@@ -16,11 +16,11 @@ use _007::Test;
             }
         }
 
-        sub x1() { return  1 }
-        sub x2() { return -1 }
-        sub x3() { return -1 }
-        sub x4() { return  1 }
-        sub x5() { return  0 }
+        func x1() { return  1 }
+        func x2() { return -1 }
+        func x3() { return -1 }
+        func x4() { return  1 }
+        func x5() { return  0 }
 
         say(A(10, x1, x2, x3, x4, x5))
         .

--- a/t/linter/sub-not-used.t
+++ b/t/linter/sub-not-used.t
@@ -4,39 +4,39 @@ use _007;
 use _007::Linter;
 
 {
-    my $program = 'sub f() {}';
+    my $program = 'func f() {}';
     my @complaints = _007.linter.lint($program);
-    ok @complaints ~~ [L::SubNotUsed], "sub not used";
+    ok @complaints ~~ [L::SubNotUsed], "func not used";
 }
 
 {
-    my $program = 'sub f() {}; f()';
+    my $program = 'func f() {}; f()';
     my @complaints = _007.linter.lint($program);
-    ok @complaints ~~ [], "sub is used; no complaint";
+    ok @complaints ~~ [], "func is used; no complaint";
 }
 
 {
-    my $program = 'sub f() {}; say(f)';
+    my $program = 'func f() {}; say(f)';
     my @complaints = _007.linter.lint($program);
-    ok @complaints ~~ [], "sub is used as argument; no complaint";
+    ok @complaints ~~ [], "func is used as argument; no complaint";
 }
 
 {
-    my $program = '{ sub f() {} }; sub f() {}; f()';
+    my $program = '{ func f() {} }; func f() {}; f()';
     my @complaints = _007.linter.lint($program);
-    ok @complaints ~~ [L::SubNotUsed], "outer sub used, but not inner";
+    ok @complaints ~~ [L::SubNotUsed], "outer func used, but not inner";
 }
 
 {
-    my $program = '{ sub f() {}; f() }; sub f() {}';
+    my $program = '{ func f() {}; f() }; func f() {}';
     my @complaints = _007.linter.lint($program);
-    ok @complaints ~~ [L::SubNotUsed], "inner sub used, but not outer";
+    ok @complaints ~~ [L::SubNotUsed], "inner func used, but not outer";
 }
 
 {
-    my $program = 'sub f() {}; for [1, 2, 3] { f() }';
+    my $program = 'func f() {}; for [1, 2, 3] { f() }';
     my @complaints = _007.linter.lint($program);
-    ok @complaints ~~ [], "using a sub from a more nested scope than it was defined";
+    ok @complaints ~~ [], "using a func from a more nested scope than it was defined";
 }
 
 done-testing;

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -37,7 +37,7 @@ Only double quotes are allowed. Strings don't have any form of
 interpolation.
 
 The `None` value is a singleton. It's the value of unassigned variables
-and subroutines that don't `return` anything.
+and function that don't `return` anything.
 
 ## Expressions
 
@@ -142,20 +142,20 @@ unconditionally, as if they were an `if 1 {}` statement.
 
     { say("hi") }       Q::Statement::Block
 
-## Subroutines
+## Functions
 
-Subroutines are similar to blocks, but they are declared with a name and
+Functions are similar to blocks, but they are declared with a name and
 a (non-optional) parameter list.
 
-    sub f(x) {}         Q::Statement::Sub
+    func f(x) {}         Q::Statement::Sub
 
-When calling a subroutine, the number of arguments must equal the number
+When calling a function, the number of arguments must equal the number
 of parameters.
 
 The parentheses in the call are mandatory. There is no `g "Mr. Bond";`
 listop form.
 
-Subroutines can return values.
+Functions can return values.
 
     return 42;          Q::Statement::Return
 
@@ -187,7 +187,7 @@ this, the assignment in the `constant` declaration is mandatory.
 ## Setting
 
 There's a scope outside the program scope, containing a few utility
-subroutines. These should be fairly self-explanatory.
+functions. These should be fairly self-explanatory.
 
     say(any)
     prompt(any)
@@ -209,7 +209,7 @@ making these two forms more or less equivalent:
 
     { quip() { say("I'd say one of their aircraft is missing") } }
 
-    sub quip() { say("I'd say one of their aircraft is missing") }
+    func quip() { say("I'd say one of their aircraft is missing") }
     { quip: quip }
 
 ## Methods on built-in types
@@ -270,7 +270,7 @@ All the different Q types can be created with an object term:
 > **Bond**: So where is this cutting edge stuff?  
 > **Q**: I'm trying to get to it!
 
-Macros are a form of routine, just like subs.
+Macros are a form of routine, just like functions.
 
     macro m(q) {}       Q::Statement::Macro
 


### PR DESCRIPTION
I wish I knew more about the etymology, but

* subprogram
* subroutine
* routine
* procedure
* function

are all kind of the same thing. (Yes, I know they're sometimes
used differently.)

Of these, "function" is the clear winner. It's the most beginner-
friendly, and easy to understand. JavaScript has made it very
popular.

It's just it's a bit long. "function". And "fun" is too short,
and a bit frivolous.

So "func" it is.

Closes #296.