### PR TITLE
Make the builtins not take input/output

### DIFF
--- a/lib/_007/Builtins.pm
+++ b/lib/_007/Builtins.pm
@@ -1,7 +1,7 @@
 use _007::Val;
 use _007::Q;
 
-sub builtins(:$input!, :$output!, :$opscope!) is export {
+sub builtins(:$opscope!) is export {
     sub wrap($_) {
         when Val | Q { $_ }
         when Nil  { NONE }
@@ -100,13 +100,10 @@ sub builtins(:$input!, :$output!, :$opscope!) is export {
 
     my @builtins =
         say => -> $arg {
-            $output.print($arg ~ "\n");
-            Nil;
+            # implementation in Runtime.pm
         },
         prompt => sub ($arg) {
-            $output.print($arg);
-            $output.flush();
-            return wrap($input.get());
+            # implementation in Runtime.pm
         },
         type => -> $arg { Val::Type.of($arg.WHAT) },
 

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -140,7 +140,7 @@ class _007::Runtime {
 
     method load-builtins {
         my $opscope = $!builtin-opscope;
-        for builtins(:$.input, :$.output, :$opscope) -> Pair (:key($name), :$value) {
+        for builtins(:$opscope) -> Pair (:key($name), :$value) {
             my $identifier = Q::Identifier.new(
                 :name(Val::Str.new(:value($name))),
                 :frame(NONE));
@@ -153,6 +153,15 @@ class _007::Runtime {
         my $argcount = @arguments.elems;
         die X::ParameterMismatch.new(:type<Sub>, :$paramcount, :$argcount)
             unless $paramcount == $argcount;
+        if $c === $!builtin-frame.properties<pad>.properties<say> {
+            $.output.print(@arguments[0].Str ~ "\n");
+            return NONE;
+        }
+        if $c === $!builtin-frame.properties<pad>.properties<prompt> {
+            $.output.print(@arguments[0].Str);
+            $.output.flush();
+            return Val::Str.new(:value($.input.get()));
+        }
         if $c.hook -> &hook {
             return &hook(|@arguments) || NONE;
         }


### PR DESCRIPTION
At the cost of intercepting their calls in the runtime, this change makes the `builtins()` sub independent of `$input` and `$output` parameters, and therefore independent of the input/output objects injected into the runtime altogether.

This is a first step in making the builtins more static/constant, in line with the vision outlined in #185.

I did this change in order to unlock the next small change: to move the initialization of the builtins outside of the `builtins()` sub.