### PR TITLE
Builtins build once

### DIFF
--- a/lib/_007/Builtins.pm
+++ b/lib/_007/Builtins.pm
@@ -1,407 +1,416 @@
 use _007::Val;
 use _007::Q;
+use _007::OpScope;
 
-sub builtins(:$opscope!) is export {
-    sub wrap($_) {
-        when Val | Q { $_ }
-        when Nil  { NONE }
-        when Bool { Val::Bool.new(:value($_)) }
-        when Int  { Val::Int.new(:value($_)) }
-        when Str  { Val::Str.new(:value($_)) }
-        when Array | Seq | List { Val::Array.new(:elements(.map(&wrap))) }
-        default { die "Got some unknown value of type ", .^name }
+sub wrap($_) {
+    when Val | Q { $_ }
+    when Nil  { NONE }
+    when Bool { Val::Bool.new(:value($_)) }
+    when Int  { Val::Int.new(:value($_)) }
+    when Str  { Val::Str.new(:value($_)) }
+    when Array | Seq | List { Val::Array.new(:elements(.map(&wrap))) }
+    default { die "Got some unknown value of type ", .^name }
+}
+
+# These multis are used below by infix:<==> and infix:<!=>
+multi equal-value($, $) { False }
+multi equal-value(Val::NoneType, Val::NoneType) { True }
+multi equal-value(Val::Bool $l, Val::Bool $r) { $l.value == $r.value }
+multi equal-value(Val::Int $l, Val::Int $r) { $l.value == $r.value }
+multi equal-value(Val::Str $l, Val::Str $r) { $l.value eq $r.value }
+multi equal-value(Val::Array $l, Val::Array $r) {
+    if %*equality-seen{$l.WHICH} && %*equality-seen{$r.WHICH} {
+        return $l === $r;
     }
+    %*equality-seen{$l.WHICH}++;
+    %*equality-seen{$r.WHICH}++;
 
-    # These multis are used below by infix:<==> and infix:<!=>
-    multi equal-value($, $) { False }
-    multi equal-value(Val::NoneType, Val::NoneType) { True }
-    multi equal-value(Val::Bool $l, Val::Bool $r) { $l.value == $r.value }
-    multi equal-value(Val::Int $l, Val::Int $r) { $l.value == $r.value }
-    multi equal-value(Val::Str $l, Val::Str $r) { $l.value eq $r.value }
-    multi equal-value(Val::Array $l, Val::Array $r) {
-        if %*equality-seen{$l.WHICH} && %*equality-seen{$r.WHICH} {
-            return $l === $r;
-        }
-        %*equality-seen{$l.WHICH}++;
-        %*equality-seen{$r.WHICH}++;
-
-        sub equal-at-index($i) {
-            equal-value($l.elements[$i], $r.elements[$i]);
-        }
-
-        [&&] $l.elements == $r.elements,
-            |(^$l.elements).map(&equal-at-index);
-    }
-    multi equal-value(Val::Object $l, Val::Object $r) {
-        if %*equality-seen{$l.WHICH} && %*equality-seen{$r.WHICH} {
-            return $l === $r;
-        }
-        %*equality-seen{$l.WHICH}++;
-        %*equality-seen{$r.WHICH}++;
-
-        sub equal-at-key(Str $key) {
-            equal-value($l.properties{$key}, $r.properties{$key});
-        }
-
-        [&&] $l.properties.keys.sort.perl eq $r.properties.keys.sort.perl,
-            |($l.properties.keys).map(&equal-at-key);
-    }
-    multi equal-value(Val::Type $l, Val::Type $r) {
-        $l.type === $r.type
-    }
-    multi equal-value(Val::Func $l, Val::Func $r) {
-        $l.name eq $r.name
-            && equal-value($l.parameterlist, $r.parameterlist)
-            && equal-value($l.statementlist, $r.statementlist)
-    }
-    multi equal-value(Q $l, Q $r) {
-        sub same-avalue($attr) {
-            equal-value($attr.get_value($l), $attr.get_value($r));
-        }
-
-        [&&] $l.WHAT === $r.WHAT,
-            |$l.attributes.map(&same-avalue);
+    sub equal-at-index($i) {
+        equal-value($l.elements[$i], $r.elements[$i]);
     }
 
-    multi less-value($, $) {
-        die X::TypeCheck.new(
-            :operation<less>,
-            :got($_),
-            :expected(Val::Int));
+    [&&] $l.elements == $r.elements,
+        |(^$l.elements).map(&equal-at-index);
+}
+multi equal-value(Val::Object $l, Val::Object $r) {
+    if %*equality-seen{$l.WHICH} && %*equality-seen{$r.WHICH} {
+        return $l === $r;
     }
-    multi less-value(Val::Int $l, Val::Int $r) { $l.value < $r.value }
-    multi less-value(Val::Str $l, Val::Str $r) { $l.value lt $r.value }
-    multi more-value($, $) {
-        die X::TypeCheck.new(
-            :operation<more>,
-            :got($_),
-            :expected(Val::Int));
-    }
-    multi more-value(Val::Int $l, Val::Int $r) { $l.value > $r.value }
-    multi more-value(Val::Str $l, Val::Str $r) { $l.value gt $r.value }
+    %*equality-seen{$l.WHICH}++;
+    %*equality-seen{$r.WHICH}++;
 
-    my role Placeholder {
-        has $.qtype;
-        has $.assoc;
-        has %.precedence;
-    }
-    my class Placeholder::MacroOp does Placeholder {
-    }
-    sub macro-op(:$qtype, :$assoc?, :%precedence?) {
-        Placeholder::MacroOp.new(:$qtype, :$assoc, :%precedence);
+    sub equal-at-key(Str $key) {
+        equal-value($l.properties{$key}, $r.properties{$key});
     }
 
-    my class Placeholder::Op does Placeholder {
-        has &.fn;
-    }
-    sub op(&fn, :$qtype, :$assoc?, :%precedence?) {
-        Placeholder::Op.new(:&fn, :$qtype, :$assoc, :%precedence);
+    [&&] $l.properties.keys.sort.perl eq $r.properties.keys.sort.perl,
+        |($l.properties.keys).map(&equal-at-key);
+}
+multi equal-value(Val::Type $l, Val::Type $r) {
+    $l.type === $r.type
+}
+multi equal-value(Val::Func $l, Val::Func $r) {
+    $l.name eq $r.name
+        && equal-value($l.parameterlist, $r.parameterlist)
+        && equal-value($l.statementlist, $r.statementlist)
+}
+multi equal-value(Q $l, Q $r) {
+    sub same-avalue($attr) {
+        equal-value($attr.get_value($l), $attr.get_value($r));
     }
 
-    my @builtins =
-        say => -> $arg {
-            # implementation in Runtime.pm
+    [&&] $l.WHAT === $r.WHAT,
+        |$l.attributes.map(&same-avalue);
+}
+
+multi less-value($, $) {
+    die X::TypeCheck.new(
+        :operation<less>,
+        :got($_),
+        :expected(Val::Int));
+}
+multi less-value(Val::Int $l, Val::Int $r) { $l.value < $r.value }
+multi less-value(Val::Str $l, Val::Str $r) { $l.value lt $r.value }
+multi more-value($, $) {
+    die X::TypeCheck.new(
+        :operation<more>,
+        :got($_),
+        :expected(Val::Int));
+}
+multi more-value(Val::Int $l, Val::Int $r) { $l.value > $r.value }
+multi more-value(Val::Str $l, Val::Str $r) { $l.value gt $r.value }
+
+my role Placeholder {
+    has $.qtype;
+    has $.assoc;
+    has %.precedence;
+}
+my class Placeholder::MacroOp does Placeholder {
+}
+sub macro-op(:$qtype, :$assoc?, :%precedence?) {
+    Placeholder::MacroOp.new(:$qtype, :$assoc, :%precedence);
+}
+
+my class Placeholder::Op does Placeholder {
+    has &.fn;
+}
+sub op(&fn, :$qtype, :$assoc?, :%precedence?) {
+    Placeholder::Op.new(:&fn, :$qtype, :$assoc, :%precedence);
+}
+
+my @builtins =
+    say => -> $arg {
+        # implementation in Runtime.pm
+    },
+    prompt => sub ($arg) {
+        # implementation in Runtime.pm
+    },
+    type => -> $arg { Val::Type.of($arg.WHAT) },
+
+    # OPERATORS (from loosest to tightest within each category)
+
+    # assignment precedence
+    'infix:=' => macro-op(
+        :qtype(Q::Infix::Assignment),
+        :assoc<right>,
+    ),
+
+    # disjunctive precedence
+    'infix:||' => macro-op(
+        :qtype(Q::Infix::Or),
+    ),
+    'infix://' => macro-op(
+        :qtype(Q::Infix::DefinedOr),
+        :precedence{ equal => "infix:||" },
+    ),
+
+    # conjunctive precedence
+    'infix:&&' => macro-op(
+        :qtype(Q::Infix::And),
+    ),
+
+    # comparison precedence
+    'infix:==' => op(
+        sub ($lhs, $rhs) {
+            my %*equality-seen;
+            return wrap(equal-value($lhs, $rhs));
         },
-        prompt => sub ($arg) {
-            # implementation in Runtime.pm
+        :qtype(Q::Infix::Eq),
+    ),
+    'infix:!=' => op(
+        sub ($lhs, $rhs) {
+            my %*equality-seen;
+            return wrap(!equal-value($lhs, $rhs))
         },
-        type => -> $arg { Val::Type.of($arg.WHAT) },
+        :qtype(Q::Infix::Ne),
+        :precedence{ equal => "infix:==" },
+    ),
+    'infix:<' => op(
+        sub ($lhs, $rhs) {
+            return wrap(less-value($lhs, $rhs))
+        },
+        :qtype(Q::Infix::Lt),
+        :precedence{ equal => "infix:==" },
+    ),
+    'infix:<=' => op(
+        sub ($lhs, $rhs) {
+            my %*equality-seen;
+            return wrap(less-value($lhs, $rhs) || equal-value($lhs, $rhs))
+        },
+        :qtype(Q::Infix::Le),
+        :precedence{ equal => "infix:==" },
+    ),
+    'infix:>' => op(
+        sub ($lhs, $rhs) {
+            return wrap(more-value($lhs, $rhs) )
+        },
+        :qtype(Q::Infix::Gt),
+        :precedence{ equal => "infix:==" },
+    ),
+    'infix:>=' => op(
+        sub ($lhs, $rhs) {
+            my %*equality-seen;
+            return wrap(more-value($lhs, $rhs) || equal-value($lhs, $rhs))
+        },
+        :qtype(Q::Infix::Ge),
+        :precedence{ equal => "infix:==" },
+    ),
+    'infix:~~' => op(
+        sub ($lhs, $rhs) {
+            die X::TypeCheck.new(:operation<~~>, :got($rhs), :expected(Val::Type))
+                unless $rhs ~~ Val::Type;
 
-        # OPERATORS (from loosest to tightest within each category)
+            return wrap($lhs ~~ $rhs.type);
+        },
+        :qtype(Q::Infix::TypeMatch),
+        :precedence{ equal => "infix:==" },
+    ),
+    'infix:!~~' => op(
+        sub ($lhs, $rhs) {
+            die X::TypeCheck.new(:operation<~~>, :got($rhs), :expected(Val::Type))
+                unless $rhs ~~ Val::Type;
 
-        # assignment precedence
-        'infix:=' => macro-op(
-            :qtype(Q::Infix::Assignment),
-            :assoc<right>,
-        ),
+            return wrap($lhs !~~ $rhs.type);
+        },
+        :qtype(Q::Infix::TypeNonMatch),
+        :precedence{ equal => "infix:==" },
+    ),
 
-        # disjunctive precedence
-        'infix:||' => macro-op(
-            :qtype(Q::Infix::Or),
-        ),
-        'infix://' => macro-op(
-            :qtype(Q::Infix::DefinedOr),
-            :precedence{ equal => "infix:||" },
-        ),
+    # cons precedence
+    'infix:::' => op(
+        sub ($lhs, $rhs) {
+            die X::TypeCheck.new(:operation<::>, :got($rhs), :expected(Val::Array))
+                unless $rhs ~~ Val::Array;
+            return wrap([$lhs, |$rhs.elements]);
+        },
+        :qtype(Q::Infix::Cons),
+        :assoc<right>,
+    ),
 
-        # conjunctive precedence
-        'infix:&&' => macro-op(
-            :qtype(Q::Infix::And),
-        ),
+    # additive precedence
+    'infix:+' => op(
+        sub ($lhs, $rhs) {
+            die X::TypeCheck.new(:operation<+>, :got($lhs), :expected(Val::Int))
+                unless $lhs ~~ Val::Int;
+            die X::TypeCheck.new(:operation<+>, :got($rhs), :expected(Val::Int))
+                unless $rhs ~~ Val::Int;
+            return wrap($lhs.value + $rhs.value);
+        },
+        :qtype(Q::Infix::Addition),
+    ),
+    'infix:~' => op(
+        sub ($lhs, $rhs) {
+            die X::TypeCheck.new(:operation<~>, :got($lhs), :expected(Val::Str))
+                unless $lhs ~~ Val::Str;
+            die X::TypeCheck.new(:operation<~>, :got($rhs), :expected(Val::Str))
+                unless $rhs ~~ Val::Str;
+            return wrap($lhs.value ~ $rhs.value);
+        },
+        :qtype(Q::Infix::Concat),
+        :precedence{ equal => "infix:+" },
+    ),
+    'infix:-' => op(
+        sub ($lhs, $rhs) {
+            die X::TypeCheck.new(:operation<->, :got($lhs), :expected(Val::Int))
+                unless $lhs ~~ Val::Int;
+            die X::TypeCheck.new(:operation<->, :got($rhs), :expected(Val::Int))
+                unless $rhs ~~ Val::Int;
+            return wrap($lhs.value - $rhs.value);
+        },
+        :qtype(Q::Infix::Subtraction),
+    ),
 
-        # comparison precedence
-        'infix:==' => op(
-            sub ($lhs, $rhs) {
-                my %*equality-seen;
-                return wrap(equal-value($lhs, $rhs));
-            },
-            :qtype(Q::Infix::Eq),
-        ),
-        'infix:!=' => op(
-            sub ($lhs, $rhs) {
-                my %*equality-seen;
-                return wrap(!equal-value($lhs, $rhs))
-            },
-            :qtype(Q::Infix::Ne),
-            :precedence{ equal => "infix:==" },
-        ),
-        'infix:<' => op(
-            sub ($lhs, $rhs) {
-                return wrap(less-value($lhs, $rhs))
-            },
-            :qtype(Q::Infix::Lt),
-            :precedence{ equal => "infix:==" },
-        ),
-        'infix:<=' => op(
-            sub ($lhs, $rhs) {
-                my %*equality-seen;
-                return wrap(less-value($lhs, $rhs) || equal-value($lhs, $rhs))
-            },
-            :qtype(Q::Infix::Le),
-            :precedence{ equal => "infix:==" },
-        ),
-        'infix:>' => op(
-            sub ($lhs, $rhs) {
-                return wrap(more-value($lhs, $rhs) )
-            },
-            :qtype(Q::Infix::Gt),
-            :precedence{ equal => "infix:==" },
-        ),
-        'infix:>=' => op(
-            sub ($lhs, $rhs) {
-                my %*equality-seen;
-                return wrap(more-value($lhs, $rhs) || equal-value($lhs, $rhs))
-            },
-            :qtype(Q::Infix::Ge),
-            :precedence{ equal => "infix:==" },
-        ),
-        'infix:~~' => op(
-            sub ($lhs, $rhs) {
-                die X::TypeCheck.new(:operation<~~>, :got($rhs), :expected(Val::Type))
-                    unless $rhs ~~ Val::Type;
+    # multiplicative precedence
+    'infix:*' => op(
+        sub ($lhs, $rhs) {
+            die X::TypeCheck.new(:operation<*>, :got($lhs), :expected(Val::Int))
+                unless $lhs ~~ Val::Int;
+            die X::TypeCheck.new(:operation<*>, :got($rhs), :expected(Val::Int))
+                unless $rhs ~~ Val::Int;
+            return wrap($lhs.value * $rhs.value);
+        },
+        :qtype(Q::Infix::Multiplication),
+    ),
+    'infix:%' => op(
+        sub ($lhs, $rhs) {
+            die X::TypeCheck.new(:operation<%>, :got($lhs), :expected(Val::Int))
+                unless $lhs ~~ Val::Int;
+            die X::TypeCheck.new(:operation<%>, :got($rhs), :expected(Val::Int))
+                unless $rhs ~~ Val::Int;
+            die X::Numeric::DivideByZero.new(:using<%>, :numerator($lhs.value))
+                if $rhs.value == 0;
+            return wrap($lhs.value % $rhs.value);
+        },
+        :qtype(Q::Infix::Modulo),
+    ),
+    'infix:%%' => op(
+        sub ($lhs, $rhs) {
+            die X::TypeCheck.new(:operation<%%>, :got($lhs), :expected(Val::Int))
+                unless $lhs ~~ Val::Int;
+            die X::TypeCheck.new(:operation<%%>, :got($rhs), :expected(Val::Int))
+                unless $rhs ~~ Val::Int;
+            die X::Numeric::DivideByZero.new(:using<%%>, :numerator($lhs.value))
+                if $rhs.value == 0;
+            return wrap($lhs.value %% $rhs.value);
+        },
+        :qtype(Q::Infix::Divisibility),
+    ),
 
-                return wrap($lhs ~~ $rhs.type);
-            },
-            :qtype(Q::Infix::TypeMatch),
-            :precedence{ equal => "infix:==" },
-        ),
-        'infix:!~~' => op(
-            sub ($lhs, $rhs) {
-                die X::TypeCheck.new(:operation<~~>, :got($rhs), :expected(Val::Type))
-                    unless $rhs ~~ Val::Type;
+    # prefixes
+    'prefix:~' => op(
+        sub prefix-str($expr) {
+            Val::Str.new(:value($expr.Str));
+        },
+        :qtype(Q::Prefix::Str),
+    ),
+    'prefix:+' => op(
+        sub prefix-plus($_) {
+            when Val::Str {
+                return wrap(.value.Int)
+                    if .value ~~ /^ '-'? \d+ $/;
+                proceed;
+            }
+            when Val::Int {
+                return $_;
+            }
+            die X::TypeCheck.new(
+                :operation("prefix:<+>"),
+                :got($_),
+                :expected(Val::Int));
+        },
+        :qtype(Q::Prefix::Plus),
+    ),
+    'prefix:-' => op(
+        sub prefix-minus($_) {
+            when Val::Str {
+                return wrap(-.value.Int)
+                    if .value ~~ /^ '-'? \d+ $/;
+                proceed;
+            }
+            when Val::Int {
+                return wrap(-.value);
+            }
+            die X::TypeCheck.new(
+                :operation("prefix:<->"),
+                :got($_),
+                :expected(Val::Int));
+        },
+        :qtype(Q::Prefix::Minus),
+    ),
+    'prefix:?' => op(
+        sub ($a) {
+            return wrap(?$a.truthy)
+        },
+        :qtype(Q::Prefix::So),
+    ),
+    'prefix:!' => op(
+        sub ($a) {
+            return wrap(!$a.truthy)
+        },
+        :qtype(Q::Prefix::Not),
+    ),
+    'prefix:^' => op(
+        sub ($n) {
+            die X::TypeCheck.new(:operation<^>, :got($n), :expected(Val::Int))
+                unless $n ~~ Val::Int;
+            return wrap([^$n.value]);
+        },
+        :qtype(Q::Prefix::Upto),
+    ),
 
-                return wrap($lhs !~~ $rhs.type);
-            },
-            :qtype(Q::Infix::TypeNonMatch),
-            :precedence{ equal => "infix:==" },
-        ),
+    # postfixes
+    'postfix:[]' => macro-op(
+        :qtype(Q::Postfix::Index),
+    ),
+    'postfix:()' => macro-op(
+        :qtype(Q::Postfix::Call),
+    ),
+    'postfix:.' => macro-op(
+        :qtype(Q::Postfix::Property),
+    ),
+;
 
-        # cons precedence
-        'infix:::' => op(
-            sub ($lhs, $rhs) {
-                die X::TypeCheck.new(:operation<::>, :got($rhs), :expected(Val::Array))
-                    unless $rhs ~~ Val::Array;
-                return wrap([$lhs, |$rhs.elements]);
-            },
-            :qtype(Q::Infix::Cons),
-            :assoc<right>,
-        ),
-
-        # additive precedence
-        'infix:+' => op(
-            sub ($lhs, $rhs) {
-                die X::TypeCheck.new(:operation<+>, :got($lhs), :expected(Val::Int))
-                    unless $lhs ~~ Val::Int;
-                die X::TypeCheck.new(:operation<+>, :got($rhs), :expected(Val::Int))
-                    unless $rhs ~~ Val::Int;
-                return wrap($lhs.value + $rhs.value);
-            },
-            :qtype(Q::Infix::Addition),
-        ),
-        'infix:~' => op(
-            sub ($lhs, $rhs) {
-                die X::TypeCheck.new(:operation<~>, :got($lhs), :expected(Val::Str))
-                    unless $lhs ~~ Val::Str;
-                die X::TypeCheck.new(:operation<~>, :got($rhs), :expected(Val::Str))
-                    unless $rhs ~~ Val::Str;
-                return wrap($lhs.value ~ $rhs.value);
-            },
-            :qtype(Q::Infix::Concat),
-            :precedence{ equal => "infix:+" },
-        ),
-        'infix:-' => op(
-            sub ($lhs, $rhs) {
-                die X::TypeCheck.new(:operation<->, :got($lhs), :expected(Val::Int))
-                    unless $lhs ~~ Val::Int;
-                die X::TypeCheck.new(:operation<->, :got($rhs), :expected(Val::Int))
-                    unless $rhs ~~ Val::Int;
-                return wrap($lhs.value - $rhs.value);
-            },
-            :qtype(Q::Infix::Subtraction),
-        ),
-
-        # multiplicative precedence
-        'infix:*' => op(
-            sub ($lhs, $rhs) {
-                die X::TypeCheck.new(:operation<*>, :got($lhs), :expected(Val::Int))
-                    unless $lhs ~~ Val::Int;
-                die X::TypeCheck.new(:operation<*>, :got($rhs), :expected(Val::Int))
-                    unless $rhs ~~ Val::Int;
-                return wrap($lhs.value * $rhs.value);
-            },
-            :qtype(Q::Infix::Multiplication),
-        ),
-        'infix:%' => op(
-            sub ($lhs, $rhs) {
-                die X::TypeCheck.new(:operation<%>, :got($lhs), :expected(Val::Int))
-                    unless $lhs ~~ Val::Int;
-                die X::TypeCheck.new(:operation<%>, :got($rhs), :expected(Val::Int))
-                    unless $rhs ~~ Val::Int;
-                die X::Numeric::DivideByZero.new(:using<%>, :numerator($lhs.value))
-                    if $rhs.value == 0;
-                return wrap($lhs.value % $rhs.value);
-            },
-            :qtype(Q::Infix::Modulo),
-        ),
-        'infix:%%' => op(
-            sub ($lhs, $rhs) {
-                die X::TypeCheck.new(:operation<%%>, :got($lhs), :expected(Val::Int))
-                    unless $lhs ~~ Val::Int;
-                die X::TypeCheck.new(:operation<%%>, :got($rhs), :expected(Val::Int))
-                    unless $rhs ~~ Val::Int;
-                die X::Numeric::DivideByZero.new(:using<%%>, :numerator($lhs.value))
-                    if $rhs.value == 0;
-                return wrap($lhs.value %% $rhs.value);
-            },
-            :qtype(Q::Infix::Divisibility),
-        ),
-
-        # prefixes
-        'prefix:~' => op(
-            sub prefix-str($expr) {
-                Val::Str.new(:value($expr.Str));
-            },
-            :qtype(Q::Prefix::Str),
-        ),
-        'prefix:+' => op(
-            sub prefix-plus($_) {
-                when Val::Str {
-                    return wrap(.value.Int)
-                        if .value ~~ /^ '-'? \d+ $/;
-                    proceed;
-                }
-                when Val::Int {
-                    return $_;
-                }
-                die X::TypeCheck.new(
-                    :operation("prefix:<+>"),
-                    :got($_),
-                    :expected(Val::Int));
-            },
-            :qtype(Q::Prefix::Plus),
-        ),
-        'prefix:-' => op(
-            sub prefix-minus($_) {
-                when Val::Str {
-                    return wrap(-.value.Int)
-                        if .value ~~ /^ '-'? \d+ $/;
-                    proceed;
-                }
-                when Val::Int {
-                    return wrap(-.value);
-                }
-                die X::TypeCheck.new(
-                    :operation("prefix:<->"),
-                    :got($_),
-                    :expected(Val::Int));
-            },
-            :qtype(Q::Prefix::Minus),
-        ),
-        'prefix:?' => op(
-            sub ($a) {
-                return wrap(?$a.truthy)
-            },
-            :qtype(Q::Prefix::So),
-        ),
-        'prefix:!' => op(
-            sub ($a) {
-                return wrap(!$a.truthy)
-            },
-            :qtype(Q::Prefix::Not),
-        ),
-        'prefix:^' => op(
-            sub ($n) {
-                die X::TypeCheck.new(:operation<^>, :got($n), :expected(Val::Int))
-                    unless $n ~~ Val::Int;
-                return wrap([^$n.value]);
-            },
-            :qtype(Q::Prefix::Upto),
-        ),
-
-        # postfixes
-        'postfix:[]' => macro-op(
-            :qtype(Q::Postfix::Index),
-        ),
-        'postfix:()' => macro-op(
-            :qtype(Q::Postfix::Call),
-        ),
-        'postfix:.' => macro-op(
-            :qtype(Q::Postfix::Property),
-        ),
-    ;
-
-    sub tree-walk(%package) {
-        for %package.keys.map({ %package ~ "::$_" }) -> $name {
-            my $type = ::($name);
-            push @builtins, ($type.^name.subst("Val::", "") => Val::Type.of($type));
-            tree-walk($type.WHO);
-        }
+sub tree-walk(%package) {
+    for %package.keys.map({ %package ~ "::$_" }) -> $name {
+        my $type = ::($name);
+        push @builtins, ($type.^name.subst("Val::", "") => Val::Type.of($type));
+        tree-walk($type.WHO);
     }
-    tree-walk(Val::);
-    tree-walk(Q::);
-    push @builtins, "Q" => Val::Type.of(Q);
+}
+tree-walk(Val::);
+tree-walk(Q::);
+push @builtins, "Q" => Val::Type.of(Q);
 
-    sub install-op($name, $placeholder) {
-        $name ~~ /^ (prefix | infix | postfix) ':' (.+) $/
-            or die "This shouldn't be an op";
-        my $type = ~$0;
-        my $opname = ~$1;
-        my $qtype = $placeholder.qtype;
-        my $assoc = $placeholder.assoc;
-        my %precedence = $placeholder.precedence;
-        $opscope.install($type, $opname, $qtype, :$assoc, :%precedence);
+my $opscope = _007::OpScope.new();
+
+sub install-op($name, $placeholder) {
+    $name ~~ /^ (prefix | infix | postfix) ':' (.+) $/
+        or die "This shouldn't be an op";
+    my $type = ~$0;
+    my $opname = ~$1;
+    my $qtype = $placeholder.qtype;
+    my $assoc = $placeholder.assoc;
+    my %precedence = $placeholder.precedence;
+    $opscope.install($type, $opname, $qtype, :$assoc, :%precedence);
+}
+
+my &ditch-sigil = { $^str.substr(1) };
+my &parameter = { Q::Parameter.new(:identifier(Q::Identifier.new(:name(Val::Str.new(:$^value))))) };
+
+@builtins.=map({
+    when .value ~~ Val::Type {
+        .key => .value;
     }
+    when .value ~~ Block {
+        my @elements = .value.signature.params».name».&ditch-sigil».&parameter;
+        my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
+        my $statementlist = Q::StatementList.new();
+        .key => Val::Func.new-builtin(.value, .key, $parameterlist, $statementlist);
+    }
+    when .value ~~ Placeholder::MacroOp {
+        my $name = .key;
+        install-op($name, .value);
+        my @elements = .value.qtype.attributes».name».substr(2).grep({ $_ ne "identifier" })».&parameter;
+        my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
+        my $statementlist = Q::StatementList.new();
+        .key => Val::Func.new-builtin(sub () {}, $name, $parameterlist, $statementlist);
+    }
+    when .value ~~ Placeholder::Op {
+        my $name = .key;
+        install-op($name, .value);
+        my &fn = .value.fn;
+        my @elements = &fn.signature.params».name».&ditch-sigil».&parameter;
+        my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
+        my $statementlist = Q::StatementList.new();
+        .key => Val::Func.new-builtin(&fn, $name, $parameterlist, $statementlist);
+    }
+    default { die "Unknown type {.value.^name}" }
+});
 
-    my &ditch-sigil = { $^str.substr(1) };
-    my &parameter = { Q::Parameter.new(:identifier(Q::Identifier.new(:name(Val::Str.new(:$^value))))) };
+sub builtins() is export {
+    return @builtins;
+}
 
-    return @builtins.map: {
-        when .value ~~ Val::Type {
-            .key => .value;
-        }
-        when .value ~~ Block {
-            my @elements = .value.signature.params».name».&ditch-sigil».&parameter;
-            my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
-            my $statementlist = Q::StatementList.new();
-            .key => Val::Func.new-builtin(.value, .key, $parameterlist, $statementlist);
-        }
-        when .value ~~ Placeholder::MacroOp {
-            my $name = .key;
-            install-op($name, .value);
-            my @elements = .value.qtype.attributes».name».substr(2).grep({ $_ ne "identifier" })».&parameter;
-            my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
-            my $statementlist = Q::StatementList.new();
-            .key => Val::Func.new-builtin(sub () {}, $name, $parameterlist, $statementlist);
-        }
-        when .value ~~ Placeholder::Op {
-            my $name = .key;
-            install-op($name, .value);
-            my &fn = .value.fn;
-            my @elements = &fn.signature.params».name».&ditch-sigil».&parameter;
-            my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
-            my $statementlist = Q::StatementList.new();
-            .key => Val::Func.new-builtin(&fn, $name, $parameterlist, $statementlist);
-        }
-        default { die "Unknown type {.value.^name}" }
-    };
+sub opscope() is export {
+    return $opscope;
 }

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -13,6 +13,8 @@ class _007::Runtime {
     has @!frames;
     has $.builtin-opscope;
     has $.builtin-frame;
+    has $!say-builtin;
+    has $!prompt-builtin;
 
     submethod BUILD(:$!input, :$!output) {
         self.enter(NO_OUTER, Val::Object.new, Q::StatementList.new);
@@ -143,6 +145,9 @@ class _007::Runtime {
                 :frame(NONE));
             self.declare-var($identifier, $value);
         }
+        my %builtins = %(builtins());
+        $!say-builtin = %builtins<say>;
+        $!prompt-builtin = %builtins<prompt>;
         $!builtin-opscope = opscope();
     }
 
@@ -151,11 +156,11 @@ class _007::Runtime {
         my $argcount = @arguments.elems;
         die X::ParameterMismatch.new(:type<Sub>, :$paramcount, :$argcount)
             unless $paramcount == $argcount;
-        if $c === $!builtin-frame.properties<pad>.properties<say> {
+        if $c === $!say-builtin {
             $.output.print(@arguments[0].Str ~ "\n");
             return NONE;
         }
-        if $c === $!builtin-frame.properties<pad>.properties<prompt> {
+        if $c === $!prompt-builtin {
             $.output.print(@arguments[0].Str);
             $.output.flush();
             return Val::Str.new(:value($.input.get()));

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -1,7 +1,6 @@
 use _007::Val;
 use _007::Q;
 use _007::Builtins;
-use _007::OpScope;
 
 constant NO_OUTER = Val::Object.new;
 constant RETURN_TO = Q::Identifier.new(
@@ -18,7 +17,6 @@ class _007::Runtime {
     submethod BUILD(:$!input, :$!output) {
         self.enter(NO_OUTER, Val::Object.new, Q::StatementList.new);
         $!builtin-frame = @!frames[*-1];
-        $!builtin-opscope = _007::OpScope.new;
         self.load-builtins;
     }
 
@@ -139,13 +137,13 @@ class _007::Runtime {
     }
 
     method load-builtins {
-        my $opscope = $!builtin-opscope;
-        for builtins(:$opscope) -> Pair (:key($name), :$value) {
+        for builtins() -> Pair (:key($name), :$value) {
             my $identifier = Q::Identifier.new(
                 :name(Val::Str.new(:value($name))),
                 :frame(NONE));
             self.declare-var($identifier, $value);
         }
+        $!builtin-opscope = opscope();
     }
 
     method call(Val::Func $c, @arguments) {


### PR DESCRIPTION
<del>Built on top of #309, so please merge that one first. [Compare against #309's branch](https://github.com/masak/007/compare/builtins-deinject-io...builtins-build-once).</del> #309 has merged.

I've moved the initialization of the builtins outside of the `builtins()` function. This mostly means that we can call this function multiple times and it will reliably return exactly the same builtins, instead of re-creating them over and over.

Also as a necessary part of this, we expose an `opscope()` function that hands back the separately-built opscope for the builtins. This rids us of the (frankly a bit silly) previous mechanism where it needed to be passed in to `builtins()` and initialized as a side effect.

As an afterthought (second commit), we can now call `builtins()` again and fish out the `say` and `prompt` stubs for later when we need to compare and intercept them. This feels more elegant than having to dig into the builtins pad.