### PR TITLE
Builtins assign whole pad

### DIFF
--- a/lib/_007/Builtins.pm
+++ b/lib/_007/Builtins.pm
@@ -407,8 +407,13 @@ my &parameter = { Q::Parameter.new(:identifier(Q::Identifier.new(:name(Val::Str.
     default { die "Unknown type {.value.^name}" }
 });
 
-sub builtins() is export {
-    return @builtins;
+my $builtins-pad = Val::Object.new;
+for @builtins -> Pair (:key($name), :$value) {
+    $builtins-pad.properties{$name} = $value;
+}
+
+sub builtins-pad() is export {
+    return $builtins-pad;
 }
 
 sub opscope() is export {

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -19,7 +19,10 @@ class _007::Runtime {
     submethod BUILD(:$!input, :$!output) {
         self.enter(NO_OUTER, Val::Object.new, Q::StatementList.new);
         $!builtin-frame = @!frames[*-1];
-        self.load-builtins;
+        $!builtin-frame.properties<pad> = builtins-pad();
+        $!say-builtin = builtins-pad().properties<say>;
+        $!prompt-builtin = builtins-pad().properties<prompt>;
+        $!builtin-opscope = opscope();
     }
 
     method run(Q::CompUnit $compunit) {
@@ -136,13 +139,6 @@ class _007::Runtime {
 
     method register-subhandler {
         self.declare-var(RETURN_TO, $.current-frame);
-    }
-
-    method load-builtins {
-        $!builtin-frame.properties<pad> = builtins-pad();
-        $!say-builtin = builtins-pad().properties<say>;
-        $!prompt-builtin = builtins-pad().properties<prompt>;
-        $!builtin-opscope = opscope();
     }
 
     method call(Val::Func $c, @arguments) {

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -139,15 +139,9 @@ class _007::Runtime {
     }
 
     method load-builtins {
-        for builtins() -> Pair (:key($name), :$value) {
-            my $identifier = Q::Identifier.new(
-                :name(Val::Str.new(:value($name))),
-                :frame(NONE));
-            self.declare-var($identifier, $value);
-        }
-        my %builtins = %(builtins());
-        $!say-builtin = %builtins<say>;
-        $!prompt-builtin = %builtins<prompt>;
+        $!builtin-frame.properties<pad> = builtins-pad();
+        $!say-builtin = builtins-pad().properties<say>;
+        $!prompt-builtin = builtins-pad().properties<prompt>;
         $!builtin-opscope = opscope();
     }
 

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -17,9 +17,11 @@ class _007::Runtime {
     has $!prompt-builtin;
 
     submethod BUILD(:$!input, :$!output) {
-        self.enter(NO_OUTER, Val::Object.new, Q::StatementList.new);
-        $!builtin-frame = @!frames[*-1];
-        $!builtin-frame.properties<pad> = builtins-pad();
+        $!builtin-frame = Val::Object.new(:properties(
+            :outer-frame(NO_OUTER),
+            :pad(builtins-pad()))
+        );
+        @!frames.push($!builtin-frame);
         $!say-builtin = builtins-pad().properties<say>;
         $!prompt-builtin = builtins-pad().properties<prompt>;
         $!builtin-opscope = opscope();


### PR DESCRIPTION
<del>This PR builds atop #310. Please merge that one first. [Compare against #310's branch](https://github.com/masak/007/compare/builtins-build-once...builtins-assign-whole-pad).</del>

This PR allows us to check the first checkbox in https://github.com/masak/007/issues/185#issuecomment-329954114 &mdash; we're now assigning the whole builtins pad in one go, circumventing the `declare-var` method.

In practice, it means that the next time I'll need to debug variable assignment, I won't get a lot of spurious debug messages when the whole builtins scope gets assigned. I consider this to be good news.

