### PR TITLE
Change func equality semantics

### DIFF
--- a/lib/_007/Builtins.pm
+++ b/lib/_007/Builtins.pm
@@ -50,9 +50,7 @@ multi equal-value(Val::Type $l, Val::Type $r) {
     $l.type === $r.type
 }
 multi equal-value(Val::Func $l, Val::Func $r) {
-    $l.name eq $r.name
-        && equal-value($l.parameterlist, $r.parameterlist)
-        && equal-value($l.statementlist, $r.statementlist)
+    $l === $r
 }
 multi equal-value(Q $l, Q $r) {
     sub same-avalue($attr) {

--- a/t/features/builtins/operators.t
+++ b/t/features/builtins/operators.t
@@ -367,11 +367,11 @@ use _007::Test;
     outputs 'say(new Q::Identifier { name: "foo" } == new Q::Identifier { name: "foo" })', "True\n",
         "two Qtrees with equal content are equal";
     outputs 'my a = []; for [1, 2] { func fn() {}; a = [fn, a] }; say(a[1][0] == a[0])',
-        "True\n", "the same func from two different frames compares favorably to itself";
-    outputs 'func foo() {}; my x = foo; { func foo() {}; say(x == foo) }', "True\n",
-        "funcs with the same name and bodies are equal (I)";
+        "False\n", "the same func from two different frames are different";
+    outputs 'func foo() {}; my x = foo; { func foo() {}; say(x == foo) }', "False\n",
+        "distinct funcs are unequal, even with the same name and bodies (I)";
     outputs 'func foo() { say("OH HAI") }; my x = foo; { func foo() { say("OH HAI") }; say(x == foo) }',
-        "True\n", "funcs with the same name and bodies are equal (II)";
+        "False\n", "distinct funcs are unequal, even with the same name and bodies (II)";
 
     outputs 'func foo() {}; func bar() {}; say(foo == bar)', "False\n",
         "distinct funcs are unequal";


### PR DESCRIPTION
Two func are now equal if and *only* if they are exactly the same
func value.

This is in direct contrast to both arrays and dicts^Wobjects, which
are compared based on their content, meaning that even distinct values
can be equal.

Closes #254.