### PR TITLE
 Make infix:<~> weakly typed

### DIFF
--- a/examples/99-bottles.007
+++ b/examples/99-bottles.007
@@ -1,10 +1,10 @@
 func verse(n) {
     func plural(n, thing) {
         if n == 1 {
-            return ~n ~ " " ~ thing;
+            return n ~ " " ~ thing;
         }
         else {
-            return ~n ~ " " ~ thing ~ "s";
+            return n ~ " " ~ thing ~ "s";
         }
     }
 

--- a/examples/euclid-gcd.007
+++ b/examples/euclid-gcd.007
@@ -15,4 +15,4 @@ if bigger < smaller {
 }
 
 say("");
-say("Greatest common denominator: " ~ ~gcd(bigger, smaller));
+say("Greatest common denominator: " ~ gcd(bigger, smaller));

--- a/examples/format.007
+++ b/examples/format.007
@@ -42,8 +42,8 @@ macro format(fmt, args) {
         my highestUsedIndex = findHighestIndex(fmt.value);
         my argCount = args.elements.size();
         if argCount <= highestUsedIndex {
-            throw new Exception { message: "Highest index was " ~ ~highestUsedIndex
-                ~ " but got only " ~ ~argCount ~ " arguments." };
+            throw new Exception { message: "Highest index was " ~ highestUsedIndex
+                ~ " but got only " ~ argCount ~ " arguments." };
         }
     }
 

--- a/examples/hanoi.007
+++ b/examples/hanoi.007
@@ -29,7 +29,7 @@ func show() {
 
 func move(diskname, from, to) {
     say("");
-    say("Moving " ~ diskname ~ " from pile " ~ ~(from + 1) ~ " to pile " ~ ~(to + 1) ~ "...");
+    say("Moving " ~ diskname ~ " from pile " ~ (from + 1) ~ " to pile " ~ (to + 1) ~ "...");
     say("");
     my disk = state[from].pop();
     state[to].push(disk);

--- a/examples/nicomachus.007
+++ b/examples/nicomachus.007
@@ -10,4 +10,4 @@ say("");
 
 my solution = (70*m3 + 21*m5 + 15*m7) % 105;
 
-say("Your number was " ~ ~(solution) ~ ".");
+say("Your number was " ~ (solution) ~ ".");

--- a/examples/quicksort.007
+++ b/examples/quicksort.007
@@ -23,7 +23,7 @@ func quicksort(array) {
 }
 
 my unsorted = (^20).shuffle();
-say("Unsorted: " ~ ~unsorted);
+say("Unsorted: " ~ unsorted);
 say("Sorting...");
 my sorted = quicksort(unsorted);
-say("Sorted: " ~ ~sorted);
+say("Sorted: " ~ sorted);

--- a/lib/_007/Builtins.pm
+++ b/lib/_007/Builtins.pm
@@ -220,11 +220,7 @@ my @builtins =
     ),
     'infix:~' => op(
         sub ($lhs, $rhs) {
-            die X::TypeCheck.new(:operation<~>, :got($lhs), :expected(Val::Str))
-                unless $lhs ~~ Val::Str;
-            die X::TypeCheck.new(:operation<~>, :got($rhs), :expected(Val::Str))
-                unless $rhs ~~ Val::Str;
-            return wrap($lhs.value ~ $rhs.value);
+            return wrap($lhs.Str ~ $rhs.Str);
         },
         :qtype(Q::Infix::Concat),
         :precedence{ equal => "infix:+" },

--- a/t/features/builtins/operators.t
+++ b/t/features/builtins/operators.t
@@ -466,11 +466,10 @@ use _007::Test;
           (stexpr (postfix:() (identifier "say") (argumentlist (infix:~ (int 38) (str "4"))))))
         .
 
-    is-error
+    is-result
         $ast,
-        X::TypeCheck,
-        "Type check failed in ~; expected Val::Str but got Val::Int (Val::Int.new(value => 38))",
-        "concatenating non-strs is an error";
+        "384\n",
+        "concatenating non-strs is OK (since #281)";
 }
 
 {


### PR DESCRIPTION
Closes #281.

The second commit removes all the now-unnecessary instances of `prefix:<~>` in the `examples/` directory.