### PR TITLE
Make 'else' blocks allow parameters

### DIFF
--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -95,8 +95,8 @@ grammar _007::Parser::Syntax {
         if <.ws> <xblock>
         [  <.ws> else <.ws>
             [
-                | <else=block>
-                | <else=statement:if>
+                | <else=.pblock>
+                | <else=.statement:if>
             ]
         ] ?
     }

--- a/lib/_007/Q.pm
+++ b/lib/_007/Q.pm
@@ -964,7 +964,14 @@ class Q::Statement::If does Q::Statement {
                     $.else.run($runtime)
                 }
                 when Q::Block {
+                    my $paramcount = $.else.parameterlist.parameters.elements.elems;
+                    die X::ParameterMismatch.new(
+                        :type("Else block"), :$paramcount, :argcount("0 or 1"))
+                        if $paramcount > 1;
                     $runtime.enter($runtime.current-frame, $.else.static-lexpad, $.else.statementlist);
+                    for @($.else.parameterlist.parameters.elements) Z $expr -> ($param, $arg) {
+                        $runtime.declare-var($param.identifier, $arg);
+                    }
                     $.else.statementlist.run($runtime);
                     $runtime.leave;
                 }

--- a/t/features/if-statement.t
+++ b/t/features/if-statement.t
@@ -145,4 +145,19 @@ use _007::Test;
         "if statement accepts only 0 or 1 argument";
 }
 
+{
+    my $program = q:to/./;
+        if 0 {
+        }
+        else -> v {
+            say("the value is falsy and it is " ~ v);
+        }
+        .
+
+    outputs
+        $program,
+        "the value is falsy and it is 0\n",
+        "else blocks can have a parameter, too (#323)";
+}
+
 done-testing;


### PR DESCRIPTION
Again, narrow use case here, but consistent.

Closes #323.