### PR TITLE
Recognize custom operators inside their own routine body

### DIFF
--- a/lib/_007/OpScope.pm
+++ b/lib/_007/OpScope.pm
@@ -2,6 +2,24 @@ use _007::Val;
 use _007::Q;
 use _007::Precedence;
 
+class X::Trait::IllegalValue is Exception {
+    has Str $.trait;
+    has Str $.value;
+
+    method message { "The value '$.value' is not compatible with the trait '$.trait'" }
+}
+
+class X::Trait::Conflict is Exception {
+    has Str $.trait1;
+    has Str $.trait2;
+
+    method message { "Traits '$.trait1' and '$.trait2' cannot coexist on the same routine" }
+}
+
+class X::Precedence::Incompatible is Exception {
+    method message { "Trying to relate a pre/postfix operator with an infix operator" }
+}
+
 class _007::OpScope {
     has %.ops =
         prefix => {},
@@ -12,6 +30,55 @@ class _007::OpScope {
     has @.infixprec;
     has @.prepostfixprec;
     has $.prepostfix-boundary = 0;
+
+    method maybe-install($identname, @trait) {
+        return
+            unless $identname ~~ /^ (< prefix infix postfix >)
+                                    ':' (.+) /;
+
+        my $type = ~$0;
+        my $op = ~$1;
+
+        my %precedence;
+        my @prec-traits = <equal looser tighter>;
+        my $assoc;
+        for @trait -> $trait {
+            my $name = $trait<identifier>.ast.name;
+            if $name eq any @prec-traits {
+                my $identifier = $trait<EXPR>.ast;
+                my $prep = $name eq "equal" ?? "to" !! "than";
+                die "The thing your op is $name $prep must be an identifier"
+                    unless $identifier ~~ Q::Identifier;
+                sub check-if-op($s) {
+                    die "Unknown thing in '$name' trait"
+                        unless $s ~~ /^ < pre in post > 'fix:' /;
+                    die X::Precedence::Incompatible.new
+                        if $type eq ('prefix' | 'postfix') && $s ~~ /^ in/
+                        || $type eq 'infix' && $s ~~ /^ < pre post >/;
+                    %precedence{$name} = $s;
+                }($identifier.name);
+            }
+            elsif $name eq "assoc" {
+                my $string = $trait<EXPR>.ast;
+                die "The associativity must be a string"
+                    unless $string ~~ Q::Literal::Str;
+                my $value = $string.value.value;
+                die X::Trait::IllegalValue.new(:trait<assoc>, :$value)
+                    unless $value eq any "left", "non", "right";
+                $assoc = $value;
+            }
+            else {
+                die "Unknown trait '$name'";
+            }
+        }
+
+        if %precedence.keys > 1 {
+            my ($t1, $t2) = %precedence.keys.sort;
+            die X::Trait::Conflict.new(:$t1, :$t2);
+        }
+
+        $*parser.opscope.install($type, $op, :%precedence, :$assoc);
+    }
 
     method install($type, $op, $q?, :%precedence, :$assoc) {
         my $name = "$type:$op";

--- a/lib/_007/Parser/Actions.pm
+++ b/lib/_007/Parser/Actions.pm
@@ -11,24 +11,10 @@ class X::PointyBlock::SinkContext is Exception {
     method message { "Pointy blocks cannot occur on the statement level" }
 }
 
-class X::Trait::Conflict is Exception {
-    has Str $.trait1;
-    has Str $.trait2;
-
-    method message { "Traits '$.trait1' and '$.trait2' cannot coexist on the same routine" }
-}
-
 class X::Trait::Duplicate is Exception {
     has Str $.trait;
 
     method message { "Trait '$.trait' is used more than once" }
-}
-
-class X::Trait::IllegalValue is Exception {
-    has Str $.trait;
-    has Str $.value;
-
-    method message { "The value '$.value' is not compatible with the trait '$.trait'" }
 }
 
 class X::Macro::Postdeclared is Exception {
@@ -46,10 +32,6 @@ class X::Op::Nonassociative is Exception {
         my $name2 = $.op2.type.substr(1, *-1);
         "'$name1' and '$name2' do not associate -- please use parentheses"
     }
-}
-
-class X::Precedence::Incompatible is Exception {
-    method message { "Trying to relate a pre/postfix operator with an infix operator" }
 }
 
 class X::Property::NotDeclared is Exception {

--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -1,77 +1,10 @@
 use _007::Val;
 use _007::Q;
 
-class X::Trait::IllegalValue is Exception {
-    has Str $.trait;
-    has Str $.value;
-
-    method message { "The value '$.value' is not compatible with the trait '$.trait'" }
-}
-
-class X::Trait::Conflict is Exception {
-    has Str $.trait1;
-    has Str $.trait2;
-
-    method message { "Traits '$.trait1' and '$.trait2' cannot coexist on the same routine" }
-}
-
-class X::Precedence::Incompatible is Exception {
-    method message { "Trying to relate a pre/postfix operator with an infix operator" }
-}
-
 sub check-feature-flag($feature, $word) {
     my $flag = "FLAG_007_{$word}";
     die "{$feature} is experimental and requires \%*ENV<{$flag}> to be set"
         unless %*ENV{$flag};
-}
-
-sub maybe-install-operator($identname, @trait) {
-    return
-        unless $identname ~~ /^ (< prefix infix postfix >)
-                                ':' (.+) /;
-
-    my $type = ~$0;
-    my $op = ~$1;
-
-    my %precedence;
-    my @prec-traits = <equal looser tighter>;
-    my $assoc;
-    for @trait -> $trait {
-        my $name = $trait<identifier>.ast.name;
-        if $name eq any @prec-traits {
-            my $identifier = $trait<EXPR>.ast;
-            my $prep = $name eq "equal" ?? "to" !! "than";
-            die "The thing your op is $name $prep must be an identifier"
-                unless $identifier ~~ Q::Identifier;
-            sub check-if-op($s) {
-                die "Unknown thing in '$name' trait"
-                    unless $s ~~ /^ < pre in post > 'fix:' /;
-                die X::Precedence::Incompatible.new
-                    if $type eq ('prefix' | 'postfix') && $s ~~ /^ in/
-                    || $type eq 'infix' && $s ~~ /^ < pre post >/;
-                %precedence{$name} = $s;
-            }($identifier.name);
-        }
-        elsif $name eq "assoc" {
-            my $string = $trait<EXPR>.ast;
-            die "The associativity must be a string"
-                unless $string ~~ Q::Literal::Str;
-            my $value = $string.value.value;
-            die X::Trait::IllegalValue.new(:trait<assoc>, :$value)
-                unless $value eq any "left", "non", "right";
-            $assoc = $value;
-        }
-        else {
-            die "Unknown trait '$name'";
-        }
-    }
-
-    if %precedence.keys > 1 {
-        my ($t1, $t2) = %precedence.keys.sort;
-        die X::Trait::Conflict.new(:$t1, :$t2);
-    }
-
-    $*parser.opscope.install($type, $op, :%precedence, :$assoc);
 }
 
 grammar _007::Parser::Syntax {
@@ -139,7 +72,7 @@ grammar _007::Parser::Syntax {
         '(' ~ ')' <parameterlist>
         <traitlist>
         {
-            maybe-install-operator($<identifier>.ast.name, $<traitlist><trait>);
+            $*parser.opscope.maybe-install($<identifier>.ast.name, $<traitlist><trait>);
         }
         [<blockoid>|| <.panic("block")>]:!s
         <.finishpad>

--- a/lib/_007/Parser/Syntax.pm
+++ b/lib/_007/Parser/Syntax.pm
@@ -1,10 +1,77 @@
 use _007::Val;
 use _007::Q;
 
+class X::Trait::IllegalValue is Exception {
+    has Str $.trait;
+    has Str $.value;
+
+    method message { "The value '$.value' is not compatible with the trait '$.trait'" }
+}
+
+class X::Trait::Conflict is Exception {
+    has Str $.trait1;
+    has Str $.trait2;
+
+    method message { "Traits '$.trait1' and '$.trait2' cannot coexist on the same routine" }
+}
+
+class X::Precedence::Incompatible is Exception {
+    method message { "Trying to relate a pre/postfix operator with an infix operator" }
+}
+
 sub check-feature-flag($feature, $word) {
     my $flag = "FLAG_007_{$word}";
     die "{$feature} is experimental and requires \%*ENV<{$flag}> to be set"
         unless %*ENV{$flag};
+}
+
+sub maybe-install-operator($identname, @trait) {
+    return
+        unless $identname ~~ /^ (< prefix infix postfix >)
+                                ':' (.+) /;
+
+    my $type = ~$0;
+    my $op = ~$1;
+
+    my %precedence;
+    my @prec-traits = <equal looser tighter>;
+    my $assoc;
+    for @trait -> $trait {
+        my $name = $trait<identifier>.ast.name;
+        if $name eq any @prec-traits {
+            my $identifier = $trait<EXPR>.ast;
+            my $prep = $name eq "equal" ?? "to" !! "than";
+            die "The thing your op is $name $prep must be an identifier"
+                unless $identifier ~~ Q::Identifier;
+            sub check-if-op($s) {
+                die "Unknown thing in '$name' trait"
+                    unless $s ~~ /^ < pre in post > 'fix:' /;
+                die X::Precedence::Incompatible.new
+                    if $type eq ('prefix' | 'postfix') && $s ~~ /^ in/
+                    || $type eq 'infix' && $s ~~ /^ < pre post >/;
+                %precedence{$name} = $s;
+            }($identifier.name);
+        }
+        elsif $name eq "assoc" {
+            my $string = $trait<EXPR>.ast;
+            die "The associativity must be a string"
+                unless $string ~~ Q::Literal::Str;
+            my $value = $string.value.value;
+            die X::Trait::IllegalValue.new(:trait<assoc>, :$value)
+                unless $value eq any "left", "non", "right";
+            $assoc = $value;
+        }
+        else {
+            die "Unknown trait '$name'";
+        }
+    }
+
+    if %precedence.keys > 1 {
+        my ($t1, $t2) = %precedence.keys.sort;
+        die X::Trait::Conflict.new(:$t1, :$t2);
+    }
+
+    $*parser.opscope.install($type, $op, :%precedence, :$assoc);
 }
 
 grammar _007::Parser::Syntax {
@@ -71,6 +138,9 @@ grammar _007::Parser::Syntax {
         <.newpad>
         '(' ~ ')' <parameterlist>
         <traitlist>
+        {
+            maybe-install-operator($<identifier>.ast.name, $<traitlist><trait>);
+        }
         [<blockoid>|| <.panic("block")>]:!s
         <.finishpad>
     }

--- a/t/features/custom-ops.t
+++ b/t/features/custom-ops.t
@@ -665,4 +665,21 @@ use _007::Test;
         "installation of custom operators sits on the right peg (#173) ('while' statement parameter)";
 }
 
+{
+    my $program = q:to/./;
+        func infix:<@->(a, b) is looser(infix:<+>) {
+            if b == 0 {
+                return a;
+            }
+            return a-1 @- b-1;
+        }
+
+        say(10 @- 3);
+        .
+
+    outputs $program, "7\n",
+        "can use custom operators already inside the body of the custom operator";
+}
+
+
 done-testing;


### PR DESCRIPTION
Somehow we have gotten to this point without being able to use a new operator X inside of X's routine body. Now we can.