### PR TITLE
Unify divide-by-zero code path

### DIFF
--- a/t/features/builtins/operators.t
+++ b/t/features/builtins/operators.t
@@ -56,7 +56,7 @@ use _007::Test;
     is-error
         $ast,
         X::Numeric::DivideByZero,
-        "Attempt to divide 5 by zero using %",
+        "Attempt to divide 5 by zero using infix:<%>",
         "dividing by 0 is an error";
 }
 
@@ -81,7 +81,7 @@ use _007::Test;
     is-error
         $ast,
         X::Numeric::DivideByZero,
-        "Attempt to divide 5 by zero using %%",
+        "Attempt to divide 5 by zero using infix:<%%>",
         "checking divisibility by 0 is an error";
 }
 
@@ -756,7 +756,7 @@ use _007::Test;
     is-error
         $ast,
         X::Numeric::DivideByZero,
-        "Attempt to divide 5 by zero using divmod",
+        "Attempt to divide 5 by zero using infix:<divmod>",
         "divmodding by 0 is an error";
 }
 


### PR DESCRIPTION
<del>Inspired by #343, with which it'll probably conflict trivially.</del> Conflict resolved.

<del>Also, heads-up, since #339 adds another division-based operator, #339 and this PR need to be sync'd up. Whichever one merges last should be rebased on the first one.</del> Also fixed.