### PR TITLE
Add `in` operator in examples

### DIFF
--- a/examples/in.007
+++ b/examples/in.007
@@ -1,0 +1,57 @@
+func infix:<in>(value, container) {
+    if container ~~ Array {
+        for container -> elem {
+            if elem == value {
+                return True;
+            }
+        }
+        return False;
+    }
+    else if container ~~ Object {
+        return container.has(value);
+    }
+    else if container ~~ Str {
+        return container.contains(~value);
+    }
+    else {
+        throw new Exception {
+            message: "Wrong type to infix:<in>. Expected Array or Object or Str, was " ~ type(container),
+        };
+    }
+}
+
+func infix:<not in>(value, container) {
+    if container ~~ Array {
+        for container -> elem {
+            if elem == value {
+                return False;
+            }
+        }
+        return True;
+    }
+    else if container ~~ Object {
+        return !container.has(value);
+    }
+    else if container ~~ Str {
+        return !container.contains(~value);
+    }
+    else {
+        throw new Exception {
+            message: "Wrong type to infix:<in>. Expected Array or Object or Str, was " ~ type(container),
+        };
+    }
+}
+
+say("foo" in { foo: 42 });              # True
+say("bar" in { foo: 42 });              # False
+say(3 in [1, 2, 3, 4]);                 # True
+say(8 in [1, 2, 3, 4]);                 # False
+say("foo" in "foolish");                # True
+say("I" in "team");                     # False
+
+say("job" not in { name: "James" });    # True
+say("name" not in { name: "James" });   # False
+say("d" not in ["a", "b", "c"]);        # True
+say("b" not in ["a", "b", "c"]);        # False
+say("we" not in "Kansas");              # True
+say("pi" not in "pie");                 # False

--- a/t/examples/in.t
+++ b/t/examples/in.t
@@ -1,0 +1,12 @@
+use Test;
+use _007::Test;
+
+my @lines = run-and-collect-lines("examples/in.007");
+
+is +@lines, 12, "correct number of lines of output";
+for [1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12] -> [$L1, $L2] {
+    is @lines[$L1 - 1], "True", "line #{$L1} correct";
+    is @lines[$L2 - 1], "False", "line #{$L2} correct";
+}
+
+done-testing;


### PR DESCRIPTION
Closes #244.

This PR doesn't live up to the letter of #244 (because it doesn't give us a new built-in operator), but it does live up to the spirit (because we get one in examples). Guess we can always re-evaluate later where it should live.