### PR TITLE
Unify code paths around running blocks

### DIFF
--- a/lib/_007/Q.pm
+++ b/lib/_007/Q.pm
@@ -951,12 +951,7 @@ class Q::Statement::If does Q::Statement {
             die X::ParameterMismatch.new(
                 :type("If statement"), :$paramcount, :argcount("0 or 1"))
                 if $paramcount > 1;
-            $runtime.enter($runtime.current-frame, $.block.static-lexpad, $.block.statementlist);
-            for @($.block.parameterlist.parameters.elements) Z $expr -> ($param, $arg) {
-                $runtime.declare-var($param.identifier, $arg);
-            }
-            $.block.statementlist.run($runtime);
-            $runtime.leave;
+            $runtime.run-block($.block, [$expr]);
         }
         else {
             given $.else {
@@ -1016,12 +1011,7 @@ class Q::Statement::For does Q::Statement {
             unless $array ~~ Val::Array;
 
         for $array.elements -> $arg {
-            $runtime.enter($runtime.current-frame, $.block.static-lexpad, $.block.statementlist);
-            if $count == 1 {
-                $runtime.declare-var($.block.parameterlist.parameters.elements[0].identifier, $arg.list[0]);
-            }
-            $.block.statementlist.run($runtime);
-            $runtime.leave;
+            $runtime.run-block($.block, $count ?? [$arg] !! []);
         }
     }
 }
@@ -1042,12 +1032,7 @@ class Q::Statement::While does Q::Statement {
             die X::ParameterMismatch.new(
                 :type("While loop"), :$paramcount, :argcount("0 or 1"))
                 if $paramcount > 1;
-            $runtime.enter($runtime.current-frame, $.block.static-lexpad, $.block.statementlist);
-            for @($.block.parameterlist.parameters.elements) Z $expr -> ($param, $arg) {
-                $runtime.declare-var($param.identifier, $arg);
-            }
-            $.block.statementlist.run($runtime);
-            $runtime.leave;
+            $runtime.run-block($.block, $paramcount ?? [$expr] !! []);0
         }
     }
 }

--- a/lib/_007/Runtime.pm
+++ b/lib/_007/Runtime.pm
@@ -143,6 +143,15 @@ class _007::Runtime {
         self.declare-var(RETURN_TO, $.current-frame);
     }
 
+    method run-block(Q::Block $block, @arguments) {
+        self.enter(self.current-frame, $block.static-lexpad, $block.statementlist);
+        for @($block.parameterlist.parameters.elements) Z @arguments -> ($param, $arg) {
+            self.declare-var($param.identifier, $arg);
+        }
+        $block.statementlist.run(self);
+        self.leave;
+    }
+
     method call(Val::Func $c, @arguments) {
         my $paramcount = $c.parameterlist.parameters.elements.elems;
         my $argcount = @arguments.elems;


### PR DESCRIPTION
There was duplicated logic in each of these, now unified:

- Q::Statement::If
- Q::Statement::For
- Q::Statement::While

Closes #337.