### PR TITLE
Change 'is equal' to 'is equiv'

### DIFF
--- a/examples/nim-addition.007
+++ b/examples/nim-addition.007
@@ -22,7 +22,7 @@ func binfmt(number) {
     return result || "0";
 }
 
-func infix:<⊕>(lhs, rhs) is equal(infix:<+>) {
+func infix:<⊕>(lhs, rhs) is equiv(infix:<+>) {
     my lb = binfmt(lhs);
     my rb = binfmt(rhs);
     lb = pad_left(lb, rb.chars(), "0");

--- a/examples/x-and-xx.007
+++ b/examples/x-and-xx.007
@@ -1,4 +1,4 @@
-macro infix:<xx>(left, right) is equal(infix:<*>) {
+macro infix:<xx>(left, right) is equiv(infix:<*>) {
     func flatten(array) {
         my result = [];
         for array -> elem {
@@ -18,7 +18,7 @@ macro infix:<xx>(left, right) is equal(infix:<*>) {
     }
 }
 
-func infix:<x>(left, right) is equal(infix:<*>) {
+func infix:<x>(left, right) is equiv(infix:<*>) {
     return (left xx right).join("");
 }
 

--- a/lib/_007/Builtins.pm6
+++ b/lib/_007/Builtins.pm6
@@ -125,7 +125,7 @@ my @builtins =
     ),
     'infix://' => macro-op(
         :qtype(Q::Infix::DefinedOr),
-        :precedence{ equal => "infix:||" },
+        :precedence{ equiv => "infix:||" },
     ),
 
     # conjunctive precedence
@@ -147,14 +147,14 @@ my @builtins =
             return wrap(!equal-value($lhs, $rhs))
         },
         :qtype(Q::Infix::Ne),
-        :precedence{ equal => "infix:==" },
+        :precedence{ equiv => "infix:==" },
     ),
     'infix:<' => op(
         sub ($lhs, $rhs) {
             return wrap(less-value($lhs, $rhs))
         },
         :qtype(Q::Infix::Lt),
-        :precedence{ equal => "infix:==" },
+        :precedence{ equiv => "infix:==" },
     ),
     'infix:<=' => op(
         sub ($lhs, $rhs) {
@@ -162,14 +162,14 @@ my @builtins =
             return wrap(less-value($lhs, $rhs) || equal-value($lhs, $rhs))
         },
         :qtype(Q::Infix::Le),
-        :precedence{ equal => "infix:==" },
+        :precedence{ equiv => "infix:==" },
     ),
     'infix:>' => op(
         sub ($lhs, $rhs) {
             return wrap(more-value($lhs, $rhs) )
         },
         :qtype(Q::Infix::Gt),
-        :precedence{ equal => "infix:==" },
+        :precedence{ equiv => "infix:==" },
     ),
     'infix:>=' => op(
         sub ($lhs, $rhs) {
@@ -177,7 +177,7 @@ my @builtins =
             return wrap(more-value($lhs, $rhs) || equal-value($lhs, $rhs))
         },
         :qtype(Q::Infix::Ge),
-        :precedence{ equal => "infix:==" },
+        :precedence{ equiv => "infix:==" },
     ),
     'infix:~~' => op(
         sub ($lhs, $rhs) {
@@ -186,7 +186,7 @@ my @builtins =
             return wrap($lhs ~~ $rhs.type);
         },
         :qtype(Q::Infix::TypeMatch),
-        :precedence{ equal => "infix:==" },
+        :precedence{ equiv => "infix:==" },
     ),
     'infix:!~~' => op(
         sub ($lhs, $rhs) {
@@ -195,7 +195,7 @@ my @builtins =
             return wrap($lhs !~~ $rhs.type);
         },
         :qtype(Q::Infix::TypeNonMatch),
-        :precedence{ equal => "infix:==" },
+        :precedence{ equiv => "infix:==" },
     ),
 
     # additive precedence
@@ -213,7 +213,7 @@ my @builtins =
             return wrap($lhs.Str ~ $rhs.Str);
         },
         :qtype(Q::Infix::Concat),
-        :precedence{ equal => "infix:+" },
+        :precedence{ equiv => "infix:+" },
     ),
     'infix:-' => op(
         sub ($lhs, $rhs) {

--- a/lib/_007/OpScope.pm6
+++ b/lib/_007/OpScope.pm6
@@ -40,13 +40,13 @@ class _007::OpScope {
         my $op = ~$1;
 
         my %precedence;
-        my @prec-traits = <equal looser tighter>;
+        my @prec-traits = <equiv looser tighter>;
         my $assoc;
         for @trait -> $trait {
             my $name = $trait<identifier>.ast.name;
             if $name eq any @prec-traits {
                 my $identifier = $trait<EXPR>.ast;
-                my $prep = $name eq "equal" ?? "to" !! "than";
+                my $prep = $name eq "equiv" ?? "to" !! "than";
                 die "The thing your op is $name $prep must be an identifier"
                     unless $identifier ~~ Q::Identifier;
                 my $s = $identifier.name;
@@ -102,7 +102,7 @@ class _007::OpScope {
                 $!prepostfix-boundary++;
             }
         }
-        elsif %precedence<equal> -> $other-op {
+        elsif %precedence<equiv> -> $other-op {
             my $prec = @namespace.first(*.contains($other-op));
             die X::Associativity::Conflict.new
                 if $assoc !=== Any && $assoc ne $prec.assoc;

--- a/t/features/custom-ops.t
+++ b/t/features/custom-ops.t
@@ -168,7 +168,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        func infix:<!?!>(left, right) is equal(infix:<+>) is equal(infix:<*>) {
+        func infix:<!?!>(left, right) is equiv(infix:<+>) is equiv(infix:<*>) {
         }
         .
 
@@ -182,7 +182,7 @@ use _007::Test;
             return "@";
         }
 
-        func infix:<!>(left, right) is equal(infix:<@>) {
+        func infix:<!>(left, right) is equiv(infix:<@>) {
             return "!";
         }
 
@@ -195,7 +195,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        func infix:<!?!>(left, right) is tighter(infix:<+>) is equal(infix:<+>) {
+        func infix:<!?!>(left, right) is tighter(infix:<+>) is equiv(infix:<+>) {
         }
         .
 
@@ -204,7 +204,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        func infix:<!++>(left, right) is looser(infix:<+>) is equal(infix:<+>) {
+        func infix:<!++>(left, right) is looser(infix:<+>) is equiv(infix:<+>) {
         }
         .
 
@@ -285,14 +285,14 @@ use _007::Test;
         func infix:<@>(left, right) is assoc("right") {
         }
 
-        func infix:<@@>(left, right) is equal(infix:<@>) {
+        func infix:<@@>(left, right) is equiv(infix:<@>) {
             return "(" ~ left ~ ", " ~ right ~ ")";
         }
 
         say("A" @@ "B" @@ "C");
         .
 
-    outputs $program, "(A, (B, C))\n", "right associativity inherits through the 'is equal' trait";
+    outputs $program, "(A, (B, C))\n", "right associativity inherits through the 'is equiv' trait";
 }
 
 {
@@ -300,14 +300,14 @@ use _007::Test;
         func infix:<@>(left, right) is assoc("non") {
         }
 
-        func infix:<@@>(left, right) is equal(infix:<@>) {
+        func infix:<@@>(left, right) is equiv(infix:<@>) {
             return "(" ~ left ~ ", " ~ right ~ ")";
         }
 
         say("A" @@ "B" @@ "C");
         .
 
-    parse-error $program, X::Op::Nonassociative, "non-associativity inherits through the 'is equal' trait";
+    parse-error $program, X::Op::Nonassociative, "non-associativity inherits through the 'is equiv' trait";
 }
 
 {
@@ -315,12 +315,12 @@ use _007::Test;
         func infix:<%>(left, right) is assoc("left") {
         }
 
-        func infix:<%%>(left, right) is equal(infix:<%>) is assoc("right") {
+        func infix:<%%>(left, right) is equiv(infix:<%>) is assoc("right") {
         }
         .
 
     parse-error $program, X::Associativity::Conflict,
-        "if you're using the 'is equal' trait, you can't contradict the associativity";
+        "if you're using the 'is equiv' trait, you can't contradict the associativity";
 }
 
 {
@@ -428,7 +428,7 @@ use _007::Test;
             return "postfix is looser";
         }
 
-        func prefix:<¿>(term) is equal(postfix:<¡>) {
+        func prefix:<¿>(term) is equiv(postfix:<¡>) {
             return "prefix is looser";
         }
 
@@ -436,7 +436,7 @@ use _007::Test;
             return "prefix is looser";
         }
 
-        func postfix:<$>(term) is equal(prefix:<%>) {
+        func postfix:<$>(term) is equiv(prefix:<%>) {
             return "postfix is looser";
         }
 
@@ -453,13 +453,13 @@ use _007::Test;
         func prefix:<¿>(left, right) is assoc("non") {
         }
 
-        func postfix:<!>(left, right) is equal(prefix:<¿>) {
+        func postfix:<!>(left, right) is equiv(prefix:<¿>) {
         }
 
         say(¿0!);
         .
 
-    parse-error $program, X::Op::Nonassociative, "non-associativity inherits through the 'is equal' trait";
+    parse-error $program, X::Op::Nonassociative, "non-associativity inherits through the 'is equiv' trait";
 }
 
 {

--- a/t/features/quasi.t
+++ b/t/features/quasi.t
@@ -260,7 +260,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Trait { is equal(infix:<+>) }));
+        say(type(quasi @ Q::Trait { is equiv(infix:<+>) }));
         .
 
     outputs $program, "<type Q::Trait>\n", "quasi @ Q::Trait";
@@ -268,7 +268,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::TraitList { is equal(infix:<+>) is assoc("right") }));
+        say(type(quasi @ Q::TraitList { is equiv(infix:<+>) is assoc("right") }));
         .
 
     outputs $program, "<type Q::TraitList>\n", "quasi @ Q::TraitList";


### PR DESCRIPTION
Because that's what Perl 6 is using.

All these years, I never noticed. Folks, it's *good* to write documentation! Good for your soul.

<del>*Note*: This branch and #351 go in different directions; whichever merges last will have to be rebased and modified a little bit manually to pass the tests.</del> Done.