### PR TITLE
Remove Q::Statement::My in favor of Q::Term::My

### DIFF
--- a/lib/_007/Backend/JavaScript.pm6
+++ b/lib/_007/Backend/JavaScript.pm6
@@ -48,20 +48,25 @@ class _007::Backend::JavaScript {
                 @main.push("say({@arguments.join(", ")});");
             }
 
-            die "Cannot handle this type of Q::Statement::Expr yet!";
-        }
-
-        multi emit-stmt(Q::Statement::My $stmt) {
-            my $name = $stmt.identifier.name.value;
-            if $stmt.expr !~~ NONE {
-                die "Cannot handle non-literal-Int rhs just yet!"
-                        unless $stmt.expr ~~ Q::Literal::Int;
-                my $expr = $stmt.expr.value.Str;
-                @main.push("let {$name} = {$expr};");
-            }
-            else {
+            when $expr ~~ Q::Term::My {
+                my $name = $expr.identifier.name.value;
                 @main.push("let {$name};");
             }
+
+            when $expr ~~ Q::Infix::Assignment
+                && $expr.lhs ~~ Q::Term::My {
+
+                my $lhs = $expr.lhs;
+                my $name = $lhs.identifier.name.value;
+                my $rhs = $expr.rhs;
+
+                die "Cannot handle non-literal-Int rhs just yet!"
+                        unless $rhs ~~ Q::Literal::Int;
+                my $int = $rhs.value.Str;
+                @main.push("let {$name} = {$int};");
+            }
+
+            die "Cannot handle this type of Q::Statement::Expr yet!";
         }
     }
 }

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -49,11 +49,6 @@ grammar _007::Parser::Syntax {
     }
 
     proto token statement {*}
-    rule statement:my {
-        my [<identifier> || <.panic("identifier")>]
-        { declare(Q::Statement::My, $<identifier>.ast.name.value); }
-        ['=' <EXPR>]?
-    }
     token statement:expr {
         <!before <!before '{{{'> '{'>   # } }}}, you're welcome vim
         <EXPR>
@@ -264,6 +259,11 @@ grammar _007::Parser::Syntax {
         <blockoid>:!s
         <.finishpad>
     }
+    token term:my {
+        my» <.ws> [<identifier> || <.panic("identifier")>]
+        { declare(Q::Term::My, $<identifier>.ast.name.value); }
+    }
+
 
     token propertylist { [<.ws> <property>]* %% [\h* ','] <.ws> }
 

--- a/lib/_007/Q.pm6
+++ b/lib/_007/Q.pm6
@@ -892,22 +892,20 @@ class Q::ArgumentList does Q {
 role Q::Statement does Q {
 }
 
-### ### Q::Statement::My
+### ### Q::Term::My
 ###
-### A `my` variable declaration statement.
+### A `my` variable declaration.
 ###
-class Q::Statement::My does Q::Statement does Q::Declaration {
+class Q::Term::My does Q::Term does Q::Declaration {
     has $.identifier;
-    has $.expr = NONE;
-
-    method attribute-order { <identifier expr> }
 
     method is-assignable { True }
 
-    method run($runtime) {
-        return
-            unless $.expr !~~ Val::NoneType;
-        my $value = $.expr.eval($runtime);
+    method eval($runtime) {
+        return $.identifier.eval($runtime);
+    }
+
+    method put-value($value, $runtime) {
         $.identifier.put-value($value, $runtime);
     }
 }

--- a/lib/_007/Val.pm6
+++ b/lib/_007/Val.pm6
@@ -37,13 +37,11 @@ role Val {
 ###     say(noreturn());    # --> `None`
 ###
 ### Finally, it's found in various places in the Q hierarchy to indicate that
-### a certain child element is not present. For example, a `my` declaration
-### can have an assignment attached to it, in which case its `expr` property
-### is a `Q::Expr` &mdash; but if no assignment is present, the `expr`
-### property is the value `None`.
+### a certain child element is not present. For example, an `if` statement
+### doesn't always have an `else` statement. When it doesn't, the `.else`
+### property is set to `None`.
 ###
-###     say(type((quasi @ Q::Statement { my x = 2 }).expr)); # --> `<type Q::Literal::Int>`
-###     say(type((quasi @ Q::Statement { my x; }).expr));    # --> `<type NoneType>`
+###     say(type((quasi @ Q::Statement { if 1 {} }).else)); # --> `<type NoneType>`
 ###
 ### The value `None` is falsy, stringifies to `None`, and doesn't numify.
 ###

--- a/t/features/q.t
+++ b/t/features/q.t
@@ -4,18 +4,6 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = new Q::Statement::My { identifier: new Q::Identifier { name: "foo" } };
-        say(q.expr);
-        .
-
-    outputs
-        $program,
-        "None\n",
-        "Q::Statement::My can be constructed without an 'expr' property (#84)";
-}
-
-{
-    my $program = q:to/./;
         my q = new Q::Statement::Return {};
         say(q.expr);
         .

--- a/t/linter/variable-declaration-assignment.t
+++ b/t/linter/variable-declaration-assignment.t
@@ -36,7 +36,7 @@ use _007::Linter;
 {
     my $program = 'my x = x';
     my @complaints = _007.linter.lint($program);
-    ok @complaints ~~ [L::RedundantAssignment], "assigning to self in declaration is redundant";
+    ok @complaints ~~ [L::RedundantAssignment, L::VariableReadBeforeAssigned], "assigning to self in declaration is redundant";
 }
 
 {

--- a/t/linter/variable-not-used.t
+++ b/t/linter/variable-not-used.t
@@ -10,6 +10,12 @@ use _007::Linter;
 }
 
 {
+    my $program = 'my x = 7';
+    my @complaints = _007.linter.lint($program);
+    ok @complaints ~~ [L::VariableNotUsed], "variable assigned but not used";
+}
+
+{
     my $program = 'my x = 7; say(x)';
     my @complaints = _007.linter.lint($program);
     ok @complaints ~~ [], "variable is used; no complaint";


### PR DESCRIPTION
<del>_(Note: This PR builds atop #364, and shouldn't merge before it. Please allow this PR to refactor on top of a merged #364 before merging this one.)_</del> Rebased.

See #279 for reasons.

In the end this was a smaller change than I feared it would be. Having made it,
I'm also more convinced (despite initial misgivings) that it's a simpler model.

(In particular, it used to be that assignment semantics resided "inside" the
`my` statement semantics. Now it's all on the outside. The `my` term, at
runtime, is completely transparent and behaves exactly like the identifier it
declares.)

It also doesn't hurt that this simpler model is also somewhat richer than the
old one. :)

Closes #279.