### PR TITLE
Change '::' to '.' as a package separator

### DIFF
--- a/examples/format.007
+++ b/examples/format.007
@@ -38,7 +38,7 @@ macro format(fmt, args) {
         }
     }
 
-    if fmt ~~ Q::Literal::Str && args ~~ Q::Term::Array {
+    if fmt ~~ Q.Literal.Str && args ~~ Q.Term.Array {
         my highestUsedIndex = findHighestIndex(fmt.value);
         my argCount = args.elements.size();
         if argCount <= highestUsedIndex {

--- a/examples/name.007
+++ b/examples/name.007
@@ -1,8 +1,8 @@
 macro name(expr) {
-    if expr ~~ Q::Postfix::Property {
+    if expr ~~ Q.Postfix.Property {
         expr = expr.property;
     }
-    if expr !~~ Q::Identifier {
+    if expr !~~ Q.Identifier {
         throw new Exception {
             message: "Cannot turn a " ~ type(expr) ~ " into a name"
         };

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -204,31 +204,31 @@ grammar _007::Parser::Syntax {
     }
     token term:quasi { quasi <.ws>
         [
-            || "@" <.ws> $<qtype>=["Q::Infix"] <.ws> '{' <.ws> <infix> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Prefix"] <.ws> '{' <.ws> <prefix> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Postfix"] <.ws> '{' <.ws> <postfix> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Expr"] <.ws> '{' <.ws> <EXPR> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Identifier"] <.ws> '{' <.ws> <term:identifier> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Block"] <.ws> '{' <.ws> <block> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::CompUnit"] <.ws> '{' <.ws> [<compunit=.unquote("Q::CompUnit")> || <compunit>] <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Literal"] <.ws> '{' <.ws> [<term:int> | <term:none> | <term:str>] <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Literal::Int"] <.ws> '{' <.ws> <term:int> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Literal::None"] <.ws> '{' <.ws> <term:none> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Literal::Str"] <.ws> '{' <.ws> <term:str> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Property"] <.ws> '{' <.ws> <property> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::PropertyList"] <.ws> '{' <.ws> <propertylist> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Term"] <.ws> '{' <.ws> <term> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Term::Array"] <.ws> '{' <.ws> <term:array> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Term::Object"] <.ws> '{' <.ws> <term:object> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Term::Quasi"] <.ws> '{' <.ws> <term:quasi> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Trait"] <.ws> '{' <.ws> <trait> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::TraitList"] <.ws> '{' <.ws> <traitlist> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Statement"] <.ws> <block>
-            || "@" <.ws> $<qtype>=["Q::StatementList"] <.ws> <block>
-            || "@" <.ws> $<qtype>=["Q::Parameter"] <.ws> '{' <.ws> <parameter> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::ParameterList"] <.ws> '{' <.ws> <parameterlist> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::ArgumentList"] <.ws> '{' <.ws> <argumentlist> <.ws> '}'
-            || "@" <.ws> $<qtype>=["Q::Unquote"] <.ws> '{' <.ws> <unquote> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Infix"] <.ws> '{' <.ws> <infix> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Prefix"] <.ws> '{' <.ws> <prefix> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Postfix"] <.ws> '{' <.ws> <postfix> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Expr"] <.ws> '{' <.ws> <EXPR> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Identifier"] <.ws> '{' <.ws> <term:identifier> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Block"] <.ws> '{' <.ws> <block> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.CompUnit"] <.ws> '{' <.ws> [<compunit=.unquote("Q.CompUnit")> || <compunit>] <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Literal"] <.ws> '{' <.ws> [<term:int> | <term:none> | <term:str>] <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Literal.Int"] <.ws> '{' <.ws> <term:int> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Literal.None"] <.ws> '{' <.ws> <term:none> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Literal.Str"] <.ws> '{' <.ws> <term:str> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Property"] <.ws> '{' <.ws> <property> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.PropertyList"] <.ws> '{' <.ws> <propertylist> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Term"] <.ws> '{' <.ws> <term> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Term.Array"] <.ws> '{' <.ws> <term:array> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Term.Object"] <.ws> '{' <.ws> <term:object> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Term.Quasi"] <.ws> '{' <.ws> <term:quasi> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Trait"] <.ws> '{' <.ws> <trait> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.TraitList"] <.ws> '{' <.ws> <traitlist> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Statement"] <.ws> <block>
+            || "@" <.ws> $<qtype>=["Q.StatementList"] <.ws> <block>
+            || "@" <.ws> $<qtype>=["Q.Parameter"] <.ws> '{' <.ws> <parameter> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.ParameterList"] <.ws> '{' <.ws> <parameterlist> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.ArgumentList"] <.ws> '{' <.ws> <argumentlist> <.ws> '}'
+            || "@" <.ws> $<qtype>=["Q.Unquote"] <.ws> '{' <.ws> <unquote> <.ws> '}'
             || "@" <.ws> (\S+) { die "Unknown Q type $0" } # XXX: turn into X::
             || <block>
             || <.panic("quasi")>
@@ -236,7 +236,15 @@ grammar _007::Parser::Syntax {
     }
     token term:new-object {
         new» <.ws>
-        <identifier> <?{ $*runtime.maybe-get-var(~$<identifier>) ~~ Val::Type }> <.ws>
+        <identifier>+ % [<.ws> "." <.ws>] <?{
+            my $type;
+            [&&] $<identifier>.map(&prefix:<~>).map(-> $identifier {
+                $type = $++
+                    ?? $*runtime.property($type, $identifier)
+                    !! $*runtime.maybe-get-var($identifier);
+                $type ~~ Val::Type;
+            });
+        }> <.ws>
         '{' ~ '}' <propertylist>
     }
     token term:object {
@@ -269,8 +277,8 @@ grammar _007::Parser::Syntax {
 
     token unquote($type?) {
         '{{{'
-        [:s <identifier> "@" ]?
-        <?{ !$type || ($<identifier> // "") eq $type }>
+        [:s <identifier> +% "." "@" ]?
+        <?{ !$type || $<identifier>.join(".") eq $type }>
         <EXPR>
         '}}}'
     }
@@ -304,7 +312,7 @@ grammar _007::Parser::Syntax {
     }
 
     rule prefix-unquote {
-        <unquote> <?{ ($<unquote><identifier> // "") eq "Q::Prefix" }>
+        <unquote> <?{ $<unquote><identifier>.join(".") eq "Q.Prefix" }>
     }
 
     method postfix {
@@ -312,7 +320,7 @@ grammar _007::Parser::Syntax {
         if /$<index>=[ <.ws> '[' ~ ']' [<.ws> <EXPR>] ]/(self) -> $cur {
             return $cur."!reduce"("postfix");
         }
-        elsif /$<call>=[ <.ws> '(' ~ ')' [<.ws> [<argumentlist=.unquote("Q::ArgumentList")> || <argumentlist>]] ]/(self) -> $cur {
+        elsif /$<call>=[ <.ws> '(' ~ ')' [<.ws> [<argumentlist=.unquote("Q.ArgumentList")> || <argumentlist>]] ]/(self) -> $cur {
             return $cur."!reduce"("postfix");
         }
         elsif /$<prop>=[ <.ws> '.' <identifier> ]/(self) -> $cur {
@@ -327,7 +335,7 @@ grammar _007::Parser::Syntax {
     }
 
     token identifier {
-        <!before \d> [\w+]+ % '::'
+        <!before \d> \w+
             [ <?after \w> || <.panic("identifier")> ]
             [ [':<' [ '\\>' | '\\\\' | <-[>]> ]+ '>']
             | [':«' [ '\\»' | '\\\\' | <-[»]> ]+ '»'] ]?

--- a/lib/_007/Q.pm6
+++ b/lib/_007/Q.pm6
@@ -307,11 +307,11 @@ class Q::Term::Tuple does Q::Term {
 ### with zero or more key/value pairs.
 ###
 class Q::Term::Object does Q::Term {
-    has Q::Identifier $.type;
+    has Val::Type $.type;
     has $.propertylist;
 
     method eval($runtime) {
-        return $runtime.get-var($.type.name.value, $.type.frame).create(
+        return $.type.create(
             $.propertylist.properties.elements.map({.key.value => .value.eval($runtime)})
         );
     }
@@ -847,7 +847,7 @@ class Q::Term::Quasi does Q::Term {
             $thing.new(|%attributes);
         }
 
-        if $.qtype.value eq "Q::Unquote" && $.contents ~~ Q::Unquote {
+        if $.qtype.value eq "Q.Unquote" && $.contents ~~ Q::Unquote {
             return $.contents;
         }
         my $r = interpolate($.contents);

--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -532,7 +532,79 @@ class _007::Runtime {
                 return Val::Tuple.new(:@elements);
             });
         }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "ArgumentList" {
+            return Val::Type.of(Q::ArgumentList);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "Block" {
+            return Val::Type.of(Q::Block);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "CompUnit" {
+            return Val::Type.of(Q::CompUnit);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "Identifier" {
+            return Val::Type.of(Q::Identifier);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "Infix" {
+            return Val::Type.of(Q::Infix);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "Literal" {
+            return Val::Type.of(Q::Literal);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "ParameterList" {
+            return Val::Type.of(Q::ParameterList);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "Postfix" {
+            return Val::Type.of(Q::Postfix);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "Prefix" {
+            return Val::Type.of(Q::Prefix);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "Statement" {
+            return Val::Type.of(Q::Statement);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "StatementList" {
+            return Val::Type.of(Q::StatementList);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "Term" {
+            return Val::Type.of(Q::Term);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Literal && $propname eq "Int" {
+            return Val::Type.of(Q::Literal::Int);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Literal && $propname eq "None" {
+            return Val::Type.of(Q::Literal::None);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Literal && $propname eq "Str" {
+            return Val::Type.of(Q::Literal::Str);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Postfix && $propname eq "Call" {
+            return Val::Type.of(Q::Postfix::Call);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Postfix && $propname eq "Property" {
+            return Val::Type.of(Q::Postfix::Property);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Statement && $propname eq "Func" {
+            return Val::Type.of(Q::Statement::Func);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Statement && $propname eq "If" {
+            return Val::Type.of(Q::Statement::If);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Statement && $propname eq "Macro" {
+            return Val::Type.of(Q::Statement::Macro);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Statement && $propname eq "My" {
+            return Val::Type.of(Q::Statement::My);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Statement && $propname eq "Return" {
+            return Val::Type.of(Q::Statement::Return);
+        }
+        elsif $obj ~~ Val::Type && $obj.type === Q::Term && $propname eq "Array" {
+            return Val::Type.of(Q::Term::Array);
+        }
         else {
+            if $obj ~~ Val::Type {
+                die X::Property::NotFound.new(:$propname, :type("$type ({$obj.type.^name})"));
+            }
             die X::Property::NotFound.new(:$propname, :$type);
         }
     }

--- a/self-host/runtime.007
+++ b/self-host/runtime.007
@@ -1,9 +1,9 @@
 my ast;
 if !ast {
-    ast = new Q::CompUnit {
-        block: new Q::Block {
-            parameterlist: new Q::ParameterList {},
-            statementlist: new Q::StatementList {
+    ast = new Q.CompUnit {
+        block: new Q.Block {
+            parameterlist: new Q.ParameterList {},
+            statementlist: new Q.StatementList {
                 statements: []
             }
         }
@@ -20,7 +20,7 @@ my Runtime = {
             frames.push(frame);
             for static_lexpad.keys() -> name {
                 my value = static_lexpad[name];
-                my identifier = new Q::Identifier { name };
+                my identifier = new Q.Identifier { name };
                 declare_var(identifier, value);
             }
         }
@@ -85,70 +85,70 @@ my Runtime = {
         }
 
         my eval_of_type = {
-            Q::Identifier(ident) {
+            "Q.Identifier": func(ident) {
                 return get_var(ident.name);
             },
-            Q::Infix::Addition(op) {
+            "Q.Infix.Addition": func(op) {
                 return eval(op.lhs) + eval(op.rhs);
             },
-            Q::Infix::And(op) {
+            "Q.Infix.And": func(op) {
                 return eval(op.lhs) && eval(op.rhs);
             },
-            Q::Infix::Assignment(op) {
+            "Q.Infix.Assignment": func(op) {
                 my value = eval(op.rhs);
-                if op.lhs ~~ Q::Identifier {    # XXX: this assumption does not always hold
+                if op.lhs ~~ Q.Identifier {    # XXX: this assumption does not always hold
                     put_var(op.lhs.name, value);
                 }
                 return value;
             },
-            Q::Infix::Concat(op) {
+            "Q.Infix.Concat": func(op) {
                 return eval(op.lhs) ~ eval(op.rhs);
             },
-            Q::Infix::Divisibility(op) {
+            "Q.Infix.Divisibility": func(op) {
                 return eval(op.lhs) %% eval(op.rhs);
             },
-            Q::Infix::Eq(op) {
+            "Q.Infix.Eq": func(op) {
                 return eval(op.lhs) == eval(op.rhs);
             },
-            Q::Infix::Ge(op) {
+            "Q.Infix.Ge": func(op) {
                 return eval(op.lhs) >= eval(op.rhs);
             },
-            Q::Infix::Gt(op) {
+            "Q.Infix.Gt": func(op) {
                 return eval(op.lhs) > eval(op.rhs);
             },
-            Q::Infix::Le(op) {
+            "Q.Infix.Le": func(op) {
                 return eval(op.lhs) <= eval(op.rhs);
             },
-            Q::Infix::Lt(op) {
+            "Q.Infix.Lt": func(op) {
                 return eval(op.lhs) < eval(op.rhs);
             },
-            Q::Infix::Multiplication(op) {
+            "Q.Infix.Multiplication": func(op) {
                 return eval(op.lhs) * eval(op.rhs);
             },
-            Q::Infix::Modulo(op) {
+            "Q.Infix.Modulo": func(op) {
                 return eval(op.lhs) % eval(op.rhs);
             },
-            Q::Infix::Ne(op) {
+            "Q.Infix.Ne": func(op) {
                 return eval(op.lhs) != eval(op.rhs);
             },
-            Q::Infix::Or(op) {
+            "Q.Infix.Or": func(op) {
                 return eval(op.lhs) || eval(op.rhs);
             },
-            Q::Infix::Subtraction(op) {
+            "Q.Infix.Subtraction": func(op) {
                 return eval(op.lhs) - eval(op.rhs);
             },
-            Q::Infix::TypeMatch(op) {
+            "Q.Infix.TypeMatch": func(op) {
                 return eval(op.lhs) ~~ eval(op.rhs);
             },
-            Q::Literal::Int(lit_int) {
+            "Q.Literal.Int": func(lit_int) {
                 return lit_int.value;
             },
-            Q::Literal::Str(lit_str) {
+            "Q.Literal.Str": func(lit_str) {
                 return lit_str.value;
             },
-            Q::Postfix::Call(op) {
+            "Q.Postfix.Call": func(op) {
                 # XXX: short-term hack to get `say` early; needs to go away
-                if op.operand ~~ Q::Identifier && op.operand.name == "say" {
+                if op.operand ~~ Q.Identifier && op.operand.name == "say" {
                     return say(eval(op.argumentlist.arguments[0]));
                 }
                 my c = eval(op.operand);
@@ -161,28 +161,28 @@ my Runtime = {
                 my arguments = op.argumentlist.arguments.map(eval);
                 return call(c, arguments);
             },
-            Q::Postfix::Index(op) {
+            "Q.Postfix.Index": func(op) {
                 return eval(op.operand)[eval(op.index)];
             },
-            Q::Postfix::Property(op) {
+            "Q.Postfix.Property": func(op) {
                 return eval(op.operand)[eval(op.property)];
             },
-            Q::Prefix::Minus(op) {
+            "Q.Prefix.Minus": func(op) {
                 return -eval(op.operand);
             },
-            Q::Prefix::So(op) {
+            "Q.Prefix.So": func(op) {
                 return ?eval(op.operand);
             },
-            Q::Prefix::Not(op) {
+            "Q.Prefix.Not": func(op) {
                 return !eval(op.operand);
             },
-            Q::Prefix::Upto(op) {
+            "Q.Prefix.Upto": func(op) {
                 return ^eval(op.operand);
             },
-            Q::Term::Array(array) {
+            "Q.Term.Array": func(array) {
                 return array.elements.map(eval);
             },
-            Q::Term::Func(term) {
+            "Q.Term.Func": func(term) {
                 my name = term.identifier && term.identifier.name || "";
                 return new Func {
                     name,
@@ -195,41 +195,41 @@ my Runtime = {
 
             # these were added to be able to run more tests
             # please move and implement as necessary
-            Q::Block(block) {
+            "Q.Block": func(block) {
             },
-            Q::Infix(op) {
+            "Q.Infix": func(op) {
             },
-            Q::Postfix(op) {
+            "Q.Postfix": func(op) {
             },
-            Q::Prefix(op) {
+            "Q.Prefix": func(op) {
             },
-            Q::Term::Object(term) {
+            "Q.Term.Object": func(term) {
             },
-            Q::Term::Quasi(term) {
+            "Q.Term.Quasi": func(term) {
             },
-            Q::Expr::BlockAdapter(adapter) {
+            "Q.Expr.BlockAdapter": func(adapter) {
             },
         };
         func eval(q) { return eval_of_type[type(q).name](q); }
 
         my run_of_type = {
-            Q::Statement::BEGIN(stmt) {
+            "Q.Statement.BEGIN": func(stmt) {
                 # no runtime behavior
             },
-            Q::CompUnit(compunit) {
+            "Q.CompUnit": func(compunit) {
                 enter(current_frame(), compunit.block["static-lexpad"]);
                 run(compunit.block.statementlist);
                 leave();
             },
-            Q::Statement::Block(stmt) {
+            "Q.Statement.Block": func(stmt) {
                 enter(current_frame(), stmt.block["static-lexpad"]);
                 run(stmt.block.statementlist);
                 leave();
             },
-            Q::Statement::Expr(stmt) {
+            "Q.Statement.Expr": func(stmt) {
                 eval(stmt.expr);
             },
-            Q::Statement::For(stmt) {
+            "Q.Statement.For": func(stmt) {
                 my array = eval(stmt.expr);
 
                 for array -> arg {
@@ -242,7 +242,7 @@ my Runtime = {
                     leave();
                 }
             },
-            Q::Statement::If(stmt) {
+            "Q.Statement.If": func(stmt) {
                 my expr = eval(stmt.expr);
                 if expr {
                     enter(current_frame(), stmt.block["static-lexpad"]);
@@ -254,19 +254,19 @@ my Runtime = {
                     leave();
                 }
             },
-            Q::Statement::Macro(stmt) {
+            "Q.Statement.Macro": func(stmt) {
                 # no runtime behavior
             },
-            Q::Statement::My(stmt) {
+            "Q.Statement.My": func(stmt) {
                 my name = stmt.identifier.name;
                 if stmt.expr {
                     put_var(name, eval(stmt.expr));
                 }
             },
-            Q::Statement::Func(stmt) {
+            "Q.Statement.Func": func(stmt) {
                 # no runtime behavior
             },
-            Q::Statement::While(stmt) {
+            "Q.Statement.While": func(stmt) {
                 my expr;
                 while expr = eval(stmt.expr) {
                     enter(current_frame(), stmt.block["static-lexpad"]);
@@ -278,7 +278,7 @@ my Runtime = {
                     leave();
                 }
             },
-            Q::StatementList(stmtlist) {
+            "Q.StatementList": func(stmtlist) {
                 for stmtlist.statements -> statement {
                     run(statement);
                 }
@@ -286,7 +286,7 @@ my Runtime = {
 
             # these were added to be able to run more tests
             # please move and implement as necessary
-            Q::Statement::Return(stmt) {
+            "Q.Statement.Return": func(stmt) {
             },
         };
         func run(q) { run_of_type[type(q).name](q); }

--- a/t/backend/ast.t
+++ b/t/backend/ast.t
@@ -8,20 +8,20 @@ my $parser = _007.parser;
     my $stringified-ast = $parser.parse($program).Str;
 
     my $expected = q:to/./.subst(/\n$/, "");
-        Q::CompUnit Q::Block {
-            parameterlist: Q::ParameterList [],
-            statementlist: Q::StatementList [Q::Statement::Expr Q::Term::Quasi {
+        Q.CompUnit Q.Block {
+            parameterlist: Q.ParameterList [],
+            statementlist: Q.StatementList [Q.Statement.Expr Q.Term.Quasi {
                 qtype: "",
-                contents: Q::Block {
-                    parameterlist: Q::ParameterList [],
-                    statementlist: Q::StatementList [Q::Statement::If {
-                        expr: Q::Unquote {
-                            qtype: Q::Term,
-                            expr: Q::Literal::Int 0
+                contents: Q.Block {
+                    parameterlist: Q.ParameterList [],
+                    statementlist: Q.StatementList [Q.Statement.If {
+                        expr: Q.Unquote {
+                            qtype: Q.Term,
+                            expr: Q.Literal.Int 0
                         },
-                        block: Q::Block {
-                            parameterlist: Q::ParameterList [],
-                            statementlist: Q::StatementList []
+                        block: Q.Block {
+                            parameterlist: Q.ParameterList [],
+                            statementlist: Q.StatementList []
                         },
                         else: None
                     }]

--- a/t/builtins/methods.t
+++ b/t/builtins/methods.t
@@ -351,10 +351,10 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(Q::Identifier.create([["name", "Steve"]]));
+        say(Q.Identifier.create([["name", "Steve"]]));
         .
 
-    outputs $program, qq[Q::Identifier "Steve"\n], "Type.create() method to create a Q::Identifier";
+    outputs $program, qq[Q.Identifier "Steve"\n], "Type.create() method to create a Q::Identifier";
 }
 
 {

--- a/t/builtins/operators.t
+++ b/t/builtins/operators.t
@@ -294,7 +294,7 @@ use _007::Test;
     outputs 'macro foo() {}; say(foo == foo)', "True\n", "a macro is equal to itself";
     outputs 'say(say == say)', "True\n", "a built-in func is equal to itself";
     outputs 'say(infix:<+> == infix:<+>)', "True\n", "a built-in operator is equal to itself";
-    outputs 'say(new Q::Identifier { name: "foo" } == new Q::Identifier { name: "foo" })', "True\n",
+    outputs 'say(new Q.Identifier { name: "foo" } == new Q.Identifier { name: "foo" })', "True\n",
         "two Qtrees with equal content are equal";
     outputs 'my a = []; for [1, 2] { func fn() {}; a = [fn, a] }; say(a[1][0] == a[0])',
         "False\n", "the same func from two different frames are different";
@@ -314,7 +314,7 @@ use _007::Test;
         "funcs with different parameters are unequal";
     outputs 'func foo() {}; my x = foo; { func foo() { say("OH HAI") }; say(x == foo) }', "False\n",
         "funcs with different bodies are unequal";
-    outputs 'say(new Q::Identifier { name: "foo" } == new Q::Identifier { name: "bar" })', "False\n",
+    outputs 'say(new Q.Identifier { name: "foo" } == new Q.Identifier { name: "bar" })', "False\n",
         "two Qtrees with distinct content are unequal";
 }
 
@@ -512,7 +512,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = quasi @ Q::Infix { + }; say(q ~~ Q::Infix)
+        my q = quasi @ Q.Infix { + }; say(q ~~ Q.Infix)
         .
 
     outputs $program, "True\n", "successful typecheck";
@@ -520,7 +520,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = quasi @ Q::Infix { + }; say(q ~~ Q::Prefix)
+        my q = quasi @ Q.Infix { + }; say(q ~~ Q.Prefix)
         .
 
     outputs $program, "False\n", "unsuccessful typecheck";
@@ -552,8 +552,8 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(quasi @ Q::Infix { + } !~~ Q::Infix);
-        say(quasi @ Q::Infix { + } !~~ Q::Prefix);
+        say(quasi @ Q.Infix { + } !~~ Q.Infix);
+        say(quasi @ Q.Infix { + } !~~ Q.Prefix);
         say(42 !~~ Int);
         say([4, 2] !~~ Array);
         say({} !~~ Object);

--- a/t/features/custom-macro-ops.t
+++ b/t/features/custom-macro-ops.t
@@ -17,7 +17,7 @@ use _007::Test;
 {
     my $program = q:to/./;
         macro infix:<!!!>(l, r) {
-            return new Q::Literal::Str { value: "OH HAI" };
+            return new Q.Literal.Str { value: "OH HAI" };
         }
 
         say(1 !!! 2);
@@ -32,7 +32,7 @@ use _007::Test;
 {
     my $program = q:to/./;
         macro prefix:<@>(x) {
-            return new Q::Literal::Str { value: "OH HAI" };
+            return new Q.Literal.Str { value: "OH HAI" };
         }
 
         say(@7);
@@ -47,7 +47,7 @@ use _007::Test;
 {
     my $program = q:to/./;
         macro postfix:<?!>(x) {
-            return new Q::Literal::Str { value: "OH HAI" };
+            return new Q.Literal.Str { value: "OH HAI" };
         }
 
         say([]?!);

--- a/t/features/if-statement.t
+++ b/t/features/if-statement.t
@@ -17,7 +17,7 @@ use _007::Test;
         if moo { say("truthy macro") }
         if {} { say("falsy object") }
         if { a: 3 } { say("truthy object") }
-        if Q::Literal::Int { say("truthy qnode") }
+        if Q.Literal.Int { say("truthy qnode") }
         .
 
     outputs $program,

--- a/t/features/macros.t
+++ b/t/features/macros.t
@@ -30,11 +30,11 @@ use _007::Test;
 {
     my $program = q:to/./;
         macro foo() {
-            return new Q::Postfix::Call {
-                identifier: new Q::Identifier { name: "postfix:()" },
-                operand: new Q::Identifier { name: "say" },
-                argumentlist: new Q::ArgumentList {
-                    arguments: [new Q::Literal::Str { value: "OH HAI" }]
+            return new Q.Postfix.Call {
+                identifier: new Q.Identifier { name: "postfix:()" },
+                operand: new Q.Identifier { name: "say" },
+                argumentlist: new Q.ArgumentList {
+                    arguments: [new Q.Literal.Str { value: "OH HAI" }]
                 }
             };
         }

--- a/t/features/objects.t
+++ b/t/features/objects.t
@@ -100,7 +100,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = new Q::Identifier { name: "foo" };
+        my q = new Q.Identifier { name: "foo" };
 
         say(q.name);
         .
@@ -113,7 +113,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = new Q::Identifier { dunnexist: "foo" };
+        my q = new Q.Identifier { dunnexist: "foo" };
         .
 
     parse-error
@@ -124,14 +124,14 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = new Q::Identifier { name: "foo" };
+        my q = new Q.Identifier { name: "foo" };
 
         say(type(q));
         .
 
     outputs
         $program,
-        qq[<type Q::Identifier>\n],
+        qq[<type Q.Identifier>\n],
         "an object literal is of the declared type";
 }
 
@@ -167,7 +167,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = new Q::Identifier {};
+        my q = new Q.Identifier {};
         .
 
     parse-error

--- a/t/features/q.t
+++ b/t/features/q.t
@@ -4,25 +4,25 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = new Q::Statement::Return {};
+        my q = new Q.Statement.Return {};
         say(q.expr);
         .
 
     outputs
         $program,
         "None\n",
-        "Q::Statement::Return can be constructed without an 'expr' property (#84)";
+        "Q.Statement.Return can be constructed without an 'expr' property (#84)";
 }
 
 {
     my $program = q:to/./;
-        my q = new Q::Statement::If {
-            expr: new Q::Literal::None {},
-            block: new Q::Block {
-                parameterlist: new Q::ParameterList {
+        my q = new Q.Statement.If {
+            expr: new Q.Literal.None {},
+            block: new Q.Block {
+                parameterlist: new Q.ParameterList {
                     parameters: []
                 },
-                statementlist: new Q::StatementList {
+                statementlist: new Q.StatementList {
                     statements: []
                 }
             }
@@ -33,16 +33,16 @@ use _007::Test;
     outputs
         $program,
         "None\n",
-        "Q::Statement::If can be constructed without an 'else' property (#84)";
+        "Q.Statement.If can be constructed without an 'else' property (#84)";
 }
 
 {
     my $program = q:to/./;
-        my q = new Q::Statement::Func {
-            identifier: new Q::Identifier { name: "foo" },
-            block: new Q::Block {
-                parameterlist: new Q::ParameterList { parameters: [] },
-                statementlist: new Q::StatementList { statements: [] }
+        my q = new Q.Statement.Func {
+            identifier: new Q.Identifier { name: "foo" },
+            block: new Q.Block {
+                parameterlist: new Q.ParameterList { parameters: [] },
+                statementlist: new Q.StatementList { statements: [] }
             }
         };
         say(q.traitlist);
@@ -50,17 +50,17 @@ use _007::Test;
 
     outputs
         $program,
-        "Q::TraitList []\n",
-        "Q::Statement::Sub can be constructed without a 'traitlist' property (#84)";
+        "Q.TraitList []\n",
+        "Q.Statement.Sub can be constructed without a 'traitlist' property (#84)";
 }
 
 {
     my $program = q:to/./;
-        my q = new Q::Statement::Macro {
-            identifier: new Q::Identifier { name: "moo" },
-            block: new Q::Block {
-                parameterlist: new Q::ParameterList { parameters: [] },
-                statementlist: new Q::StatementList { statements: [] }
+        my q = new Q.Statement.Macro {
+            identifier: new Q.Identifier { name: "moo" },
+            block: new Q.Block {
+                parameterlist: new Q.ParameterList { parameters: [] },
+                statementlist: new Q.StatementList { statements: [] }
             }
         };
         say(q.traitlist);
@@ -68,8 +68,8 @@ use _007::Test;
 
     outputs
         $program,
-        "Q::TraitList []\n",
-        "Q::Statement::Macro can be constructed without a 'traitlist' property (#84)";
+        "Q.TraitList []\n",
+        "Q.Statement.Macro can be constructed without a 'traitlist' property (#84)";
 }
 
 done-testing;

--- a/t/features/quasi.t
+++ b/t/features/quasi.t
@@ -84,113 +84,113 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Infix { + }));
+        say(type(quasi @ Q.Infix { + }));
         .
 
-    outputs $program, "<type Q::Infix::Addition>\n", "quasi @ Q::Infix";
+    outputs $program, "<type Q.Infix.Addition>\n", "quasi @ Q.Infix";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Prefix { - }));
+        say(type(quasi @ Q.Prefix { - }));
         .
 
-    outputs $program, "<type Q::Prefix::Minus>\n", "quasi @ Q::Prefix";
+    outputs $program, "<type Q.Prefix.Minus>\n", "quasi @ Q.Prefix";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Postfix { .foo }));
+        say(type(quasi @ Q.Postfix { .foo }));
         .
 
-    outputs $program, "<type Q::Postfix::Property>\n", "quasi @ Q::Postfix";
+    outputs $program, "<type Q.Postfix.Property>\n", "quasi @ Q.Postfix";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Expr { 2 + (2 + 2) + -2 + [2][2] }));
+        say(type(quasi @ Q.Expr { 2 + (2 + 2) + -2 + [2][2] }));
         .
 
-    outputs $program, "<type Q::Infix::Addition>\n", "quasi @ Q::Expr";
+    outputs $program, "<type Q.Infix.Addition>\n", "quasi @ Q.Expr";
 }
 
 {
     my $program = q:to/./;
         my foo;
-        say(type(quasi @ Q::Identifier { foo }));
+        say(type(quasi @ Q.Identifier { foo }));
         .
 
-    outputs $program, "<type Q::Identifier>\n", "quasi @ Q::Identifier";
+    outputs $program, "<type Q.Identifier>\n", "quasi @ Q.Identifier";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Block { { say("Bond") } }));
+        say(type(quasi @ Q.Block { { say("Bond") } }));
         .
 
-    outputs $program, "<type Q::Block>\n", "quasi @ Q::Block";
+    outputs $program, "<type Q.Block>\n", "quasi @ Q.Block";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::CompUnit { say("James"); }));
+        say(type(quasi @ Q.CompUnit { say("James"); }));
         .
 
-    outputs $program, "<type Q::CompUnit>\n", "quasi @ Q::CompUnit";
+    outputs $program, "<type Q.CompUnit>\n", "quasi @ Q.CompUnit";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Literal { 7 }));
-        say(type(quasi @ Q::Literal { None }));
-        say(type(quasi @ Q::Literal { "James Bond" }));
+        say(type(quasi @ Q.Literal { 7 }));
+        say(type(quasi @ Q.Literal { None }));
+        say(type(quasi @ Q.Literal { "James Bond" }));
         .
 
     outputs $program,
-        "<type Q::Literal::Int>\n<type Q::Literal::None>\n<type Q::Literal::Str>\n",
-        "quasi @ Q::Literal";
+        "<type Q.Literal.Int>\n<type Q.Literal.None>\n<type Q.Literal.Str>\n",
+        "quasi @ Q.Literal";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Literal::Int { 7 }));
+        say(type(quasi @ Q.Literal.Int { 7 }));
         .
 
-    outputs $program, "<type Q::Literal::Int>\n", "quasi @ Q::Literal::Int";
+    outputs $program, "<type Q.Literal.Int>\n", "quasi @ Q.Literal.Int";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Literal::None { None }));
+        say(type(quasi @ Q.Literal.None { None }));
         .
 
-    outputs $program, "<type Q::Literal::None>\n", "quasi @ Q::Literal::None";
+    outputs $program, "<type Q.Literal.None>\n", "quasi @ Q.Literal.None";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Literal::Str { "James Bond" }));
+        say(type(quasi @ Q.Literal.Str { "James Bond" }));
         .
 
-    outputs $program, "<type Q::Literal::Str>\n", "quasi @ Q::Literal::Str";
+    outputs $program, "<type Q.Literal.Str>\n", "quasi @ Q.Literal.Str";
 }
 
 {
     my $program = q:to/./;
         my prop;
-        say(type(quasi @ Q::Property { key: "value" }));
-        say(type(quasi @ Q::Property { "key": "value" }));
-        say(type(quasi @ Q::Property { fn() {} }));
-        say(type(quasi @ Q::Property { prop }));
+        say(type(quasi @ Q.Property { key: "value" }));
+        say(type(quasi @ Q.Property { "key": "value" }));
+        say(type(quasi @ Q.Property { fn() {} }));
+        say(type(quasi @ Q.Property { prop }));
         .
 
-    outputs $program, "<type Q::Property>\n" x 4, "quasi @ Q::Property";
+    outputs $program, "<type Q.Property>\n" x 4, "quasi @ Q.Property";
 }
 
 {
     my $program = q:to/./;
         my prop;
-        my q = quasi @ Q::PropertyList {
+        my q = quasi @ Q.PropertyList {
             key1: "value",
             "key2": "value",
             fn() {},
@@ -201,136 +201,136 @@ use _007::Test;
         say(q.properties.size());
         .
 
-    outputs $program, "<type Q::PropertyList>\n4\n", "quasi @ Q::PropertyList";
+    outputs $program, "<type Q.PropertyList>\n4\n", "quasi @ Q.PropertyList";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Term { 7 }));
-        say(type(quasi @ Q::Term { None }));
-        say(type(quasi @ Q::Term { "James Bond" }));
-        say(type(quasi @ Q::Term { [0, 0, 7] }));
-        say(type(quasi @ Q::Term { new Object { james: "Bond" } }));
-        say(type(quasi @ Q::Term { quasi { say("oh, james!") } }));
-        say(type(quasi @ Q::Term { (0 + 0 + 7) }));
+        say(type(quasi @ Q.Term { 7 }));
+        say(type(quasi @ Q.Term { None }));
+        say(type(quasi @ Q.Term { "James Bond" }));
+        say(type(quasi @ Q.Term { [0, 0, 7] }));
+        say(type(quasi @ Q.Term { new Object { james: "Bond" } }));
+        say(type(quasi @ Q.Term { quasi { say("oh, james!") } }));
+        say(type(quasi @ Q.Term { (0 + 0 + 7) }));
         .
 
     outputs $program,
-        <Literal::Int Literal::None Literal::Str
-            Term::Array Term::Object Term::Quasi
-            Infix::Addition>\
-            .map({ "<type Q::$_>\n" }).join,
-        "quasi @ Q::Term";
+        <Literal.Int Literal.None Literal.Str
+            Term.Array Term.Object Term.Quasi
+            Infix.Addition>\
+            .map({ "<type Q.$_>\n" }).join,
+        "quasi @ Q.Term";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Term::Array { [0, 0, 7] }));
+        say(type(quasi @ Q.Term.Array { [0, 0, 7] }));
         .
 
-    outputs $program, "<type Q::Term::Array>\n", "quasi @ Q::Term::Array";
+    outputs $program, "<type Q.Term.Array>\n", "quasi @ Q.Term.Array";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Term::Object { new Object { james: "Bond" } }));
+        say(type(quasi @ Q.Term.Object { new Object { james: "Bond" } }));
         .
 
-    outputs $program, "<type Q::Term::Object>\n", "quasi @ Q::Term::Object";
+    outputs $program, "<type Q.Term.Object>\n", "quasi @ Q.Term.Object";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Term::Quasi { quasi { say("oh, james!") } }));
+        say(type(quasi @ Q.Term.Quasi { quasi { say("oh, james!") } }));
         .
 
-    outputs $program, "<type Q::Term::Quasi>\n", "quasi @ Q::Term::Quasi";
+    outputs $program, "<type Q.Term.Quasi>\n", "quasi @ Q.Term.Quasi";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Trait { is equiv(infix:<+>) }));
+        say(type(quasi @ Q.Trait { is equiv(infix:<+>) }));
         .
 
-    outputs $program, "<type Q::Trait>\n", "quasi @ Q::Trait";
+    outputs $program, "<type Q.Trait>\n", "quasi @ Q.Trait";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::TraitList { is equiv(infix:<+>) is assoc("right") }));
+        say(type(quasi @ Q.TraitList { is equiv(infix:<+>) is assoc("right") }));
         .
 
-    outputs $program, "<type Q::TraitList>\n", "quasi @ Q::TraitList";
+    outputs $program, "<type Q.TraitList>\n", "quasi @ Q.TraitList";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Statement { say("james") }));
-        say(type(quasi @ Q::Statement { say("bond"); }));
+        say(type(quasi @ Q.Statement { say("james") }));
+        say(type(quasi @ Q.Statement { say("bond"); }));
         .
 
-    outputs $program, "<type Q::Statement::Expr>\n" x 2, "quasi @ Q::Statement";
+    outputs $program, "<type Q.Statement.Expr>\n" x 2, "quasi @ Q.Statement";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::StatementList { say("james"); say("bond") }));
-        say(type(quasi @ Q::StatementList { say("james"); say("bond"); }));
+        say(type(quasi @ Q.StatementList { say("james"); say("bond") }));
+        say(type(quasi @ Q.StatementList { say("james"); say("bond"); }));
         .
 
-    outputs $program, "<type Q::StatementList>\n" x 2, "quasi @ Q::StatementList";
+    outputs $program, "<type Q.StatementList>\n" x 2, "quasi @ Q.StatementList";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::Parameter { foo }));
+        say(type(quasi @ Q.Parameter { foo }));
         .
 
-    outputs $program, "<type Q::Parameter>\n", "quasi @ Q::Parameter";
+    outputs $program, "<type Q.Parameter>\n", "quasi @ Q.Parameter";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::ParameterList { james, tiberius, bond }));
+        say(type(quasi @ Q.ParameterList { james, tiberius, bond }));
         .
 
-    outputs $program, "<type Q::ParameterList>\n", "quasi @ Q::ParameterList";
+    outputs $program, "<type Q.ParameterList>\n", "quasi @ Q.ParameterList";
 }
 
 {
     my $program = q:to/./;
-        say(type(quasi @ Q::ArgumentList { 1, "foo", [0, 0, 7] }));
+        say(type(quasi @ Q.ArgumentList { 1, "foo", [0, 0, 7] }));
         .
 
-    outputs $program, "<type Q::ArgumentList>\n", "quasi @ Q::ArgumentList";
+    outputs $program, "<type Q.ArgumentList>\n", "quasi @ Q.ArgumentList";
 }
 
 {
     my $program = q:to/./;
         my q = quasi { say("oh, james") };
-        say(type(quasi @ Q::Unquote { {{{q}}} }));
+        say(type(quasi @ Q.Unquote { {{{q}}} }));
         .
 
-    outputs $program, "<type Q::Unquote>\n", "quasi @ Q::Unquote";
+    outputs $program, "<type Q.Unquote>\n", "quasi @ Q.Unquote";
 }
 
 {
     my $program = q:to/./;
-        my q1 = quasi @ Q::Statement { my x; };
-        my q2 = quasi @ Q::Statement { my x; };
+        my q1 = quasi @ Q.Statement { my x; };
+        my q2 = quasi @ Q.Statement { my x; };
         say("alive");
         .
 
-    outputs $program, "alive\n", "Q::Statement quasis don't leak (I)";
+    outputs $program, "alive\n", "Q.Statement quasis don't leak (I)";
 }
 
 {
     my $program = q:to/./;
-        my q1 = quasi @ Q::Statement { my x; };
+        my q1 = quasi @ Q.Statement { my x; };
         say(x);
         .
 
-    parse-error $program, X::Undeclared, "Q::Statement quasis don't leak (II)";
+    parse-error $program, X::Undeclared, "Q.Statement quasis don't leak (II)";
 }
 
 {

--- a/t/features/types.t
+++ b/t/features/types.t
@@ -60,7 +60,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        new Q::Literal {}
+        new Q.Literal {}
         .
 
     parse-error

--- a/t/features/unquote.t
+++ b/t/features/unquote.t
@@ -6,7 +6,7 @@ use _007::Test;
     my $program = q:to/./;
         my greeting_ast;
         BEGIN {
-            greeting_ast = new Q::Literal::Str { value: "Mr Bond!" };
+            greeting_ast = new Q.Literal.Str { value: "Mr Bond!" };
         }
 
         macro foo() {
@@ -40,21 +40,21 @@ use _007::Test;
 {
     my $program = q:to/./;
         macro moo() {
-            my q = quasi @ Q::Infix { + };
-            return quasi { say(2 {{{Q::Infix @ q}}} 2) };
+            my q = quasi @ Q.Infix { + };
+            return quasi { say(2 {{{Q.Infix @ q}}} 2) };
         }
 
         moo();
         .
 
-    outputs $program, "4\n", "Q::Infix @ unquote";
+    outputs $program, "4\n", "Q.Infix @ unquote";
 }
 
 {
     my $program = q:to/./;
         macro moo() {
-            my q = quasi @ Q::Term { "foo" };
-            return quasi { say(2 {{{Q::Infix @ q}}} 2) };
+            my q = quasi @ Q.Term { "foo" };
+            return quasi { say(2 {{{Q.Infix @ q}}} 2) };
         }
 
         moo();
@@ -62,14 +62,14 @@ use _007::Test;
 
     parse-error $program,
         X::TypeCheck,
-        "can't put a non-infix in a Q::Infix @ unquote";
+        "can't put a non-infix in a Q.Infix @ unquote";
 }
 
 {
     my $program = q:to/./;
         macro moo() {
-            my q = quasi @ Q::Infix { + };
-            return quasi { say(2 {{{Q::Term @ q}}} 2) };
+            my q = quasi @ Q.Infix { + };
+            return quasi { say(2 {{{Q.Term @ q}}} 2) };
         }
 
         moo();
@@ -83,7 +83,7 @@ use _007::Test;
 {
     my $program = q:to/./;
         macro moo() {
-            my q = quasi @ Q::Infix { + };
+            my q = quasi @ Q.Infix { + };
             return quasi { say(2 {{{q}}} 2) };
         }
 
@@ -98,21 +98,21 @@ use _007::Test;
 {
     my $program = q:to/./;
         macro moo() {
-            my q = quasi @ Q::Prefix { - };
-            return quasi { say({{{Q::Prefix @ q}}} 17) };
+            my q = quasi @ Q.Prefix { - };
+            return quasi { say({{{Q.Prefix @ q}}} 17) };
         }
 
         moo();
         .
 
-    outputs $program, "-17\n", "Q::Prefix @ unquote";
+    outputs $program, "-17\n", "Q.Prefix @ unquote";
 }
 
 {
     my $program = q:to/./;
         macro moo() {
-            my q = quasi @ Q::Term { "foo" };
-            return quasi { say({{{Q::Prefix @ q}}} 17) };
+            my q = quasi @ Q.Term { "foo" };
+            return quasi { say({{{Q.Prefix @ q}}} 17) };
         }
 
         moo();
@@ -120,7 +120,7 @@ use _007::Test;
 
     parse-error $program,
         X::TypeCheck,
-        "can't put a non-prefix in a Q::Prefix @ unquote";
+        "can't put a non-prefix in a Q.Prefix @ unquote";
 }
 
 {
@@ -132,23 +132,23 @@ use _007::Test;
         }
 
         macro moo() {
-            my q = quasi @ Q::ArgumentList { 1, "foo", [0, 0, 7] };
-            return quasi { foo({{{Q::ArgumentList @ q}}}) };
+            my q = quasi @ Q.ArgumentList { 1, "foo", [0, 0, 7] };
+            return quasi { foo({{{Q.ArgumentList @ q}}}) };
         }
 
         moo();
         .
 
-    outputs $program, "1\nfoo\n[0, 0, 7]\n", "Q::ArgumentList @ unquote";
+    outputs $program, "1\nfoo\n[0, 0, 7]\n", "Q.ArgumentList @ unquote";
 }
 
 {
     my $program = q:to/./;
-        my q = quasi @ Q::CompUnit { say("James"); };
-        say(type(quasi @ Q::CompUnit { {{{Q::CompUnit @ q}}} }));
+        my q = quasi @ Q.CompUnit { say("James"); };
+        say(type(quasi @ Q.CompUnit { {{{Q.CompUnit @ q}}} }));
         .
 
-    outputs $program, "<type Q::CompUnit>\n", "Q::CompUnit @ q";
+    outputs $program, "<type Q.CompUnit>\n", "Q.CompUnit @ q";
 }
 
 {


### PR DESCRIPTION
This change charges some extra onto the already debt-ridden
'property' method in Runtime.pm6. It's overdue for some
cleanup; maybe even before one that affects the entire object
system.

In general, this change introduces technical debt here and
there, which can either be cleaned up gradually, or as part
of a bigger object system rework. Until then, we already
have the dot separator, and we've cleaned up `::` for other
things (such as a custom operator).

There are a couple of places in the language where previously
we expected "one identifier" denoting a type, but now it's a
chain of dot-separated identifiers instead; what #250 calls a
"name":

- After `new`
- After `quasi @`
- Before the `@` in unquotes

The "neat" shortcut in self-host/runtime.007 where we used
the Q hierarchy type "identifiers" as object/dictionary keys
had to go. But that was a price we had to pay at some point
anyway.

Closes #250.
Closes #298.