### PR TITLE
Remove Q subtypes from the builtins

### DIFF
--- a/lib/_007/Builtins.pm6
+++ b/lib/_007/Builtins.pm6
@@ -345,7 +345,6 @@ sub tree-walk(%package) {
     }
 }
 tree-walk(Val::);
-tree-walk(Q::);
 push @builtins, "Q" => Val::Type.of(Q);
 
 my $opscope = _007::OpScope.new();

--- a/lib/_007/Builtins.pm6
+++ b/lib/_007/Builtins.pm6
@@ -337,14 +337,10 @@ my @builtins =
     ),
 ;
 
-sub tree-walk(%package) {
-    for %package.keys.map({ %package ~ "::$_" }) -> $name {
-        my $type = ::($name);
-        push @builtins, ($type.^name.subst("Val::", "") => Val::Type.of($type));
-        tree-walk($type.WHO);
-    }
+for Val::.keys.map({ "Val::" ~ $_ }) -> $name {
+    my $type = ::($name);
+    push @builtins, ($type.^name.subst("Val::", "") => Val::Type.of($type));
 }
-tree-walk(Val::);
 push @builtins, "Q" => Val::Type.of(Q);
 
 my $opscope = _007::OpScope.new();


### PR DESCRIPTION
I noticed when printing the builtins that subtypes of Q such as `Q::Identifier` were still showing up there. That's old news; since the `.` separator we don't even spell them that way.

Just a small fix.