### PR TITLE
Make prompt return None when EOF (^D) is sent to it

### DIFF
--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -169,7 +169,12 @@ class _007::Runtime {
         if $c === $!prompt-builtin {
             $.output.print(@arguments[0].Str);
             $.output.flush();
-            return Val::Str.new(:value($.input.get()));
+            my $value = $.input.get();
+            if !$value.defined {
+                $.output.print("\n");
+                return NONE;
+            }
+            return Val::Str.new(:$value);
         }
         if $c.hook -> &hook {
             return &hook(|@arguments) || NONE;

--- a/lib/_007/Test.pm6
+++ b/lib/_007/Test.pm6
@@ -67,9 +67,21 @@ sub runtime-error($program, $expected-error, $desc = $expected-error.^name) is e
     }
 }
 
-sub outputs($program, $expected, $desc = "MISSING TEST DESCRIPTION") is export {
+sub outputs($program, $expected, $desc = "MISSING TEST DESCRIPTION", :@indata = []) is export {
+    class InputFromData {
+        has @.indata;
+        has $!index = 0;
+
+        method get() {
+            return $!index < @.indata
+                ?? @.indata[$!index++]
+                !! Nil;
+        }
+    }
+
+    my $input = InputFromData.new(:@indata);
     my $output = StrOutput.new;
-    my $runtime = _007.runtime(:$output);
+    my $runtime = _007.runtime(:$input, :$output);
     my $parser = _007.parser(:$runtime);
     my $ast = $parser.parse($program);
     $runtime.run($ast);

--- a/t/builtins/funcs.t
+++ b/t/builtins/funcs.t
@@ -12,6 +12,14 @@ use _007::Test;
 
 {
     my $program = q:to/./;
+        say(type(prompt(">>> ")));
+        .
+
+    outputs $program, ">>> \n<type NoneType>\n", "say() works";
+}
+
+{
+    my $program = q:to/./;
         say(type(None));
         .
 


### PR DESCRIPTION
This one just occurred to me all of a sudden: prompt shouldn't return a `Str` if the user sends an end-of-file instead of inputting a line. (I was thinking about reading an entire file from STDIN, which is why I thought of it.)

And indeed, before this PR we had a hidden bug, where 007 would create a malformed `Str` with a `Nil` inside of it!