### PR TITLE
Implement exit() builtin

### DIFF
--- a/bin/007
+++ b/bin/007
@@ -30,6 +30,7 @@ sub run_007($program, Str $backend is copy) {
     my $unexpanded = $backend eq "unexpanded-ast";
     my $ast = _007.parser(:$runtime).parse($program, :$unexpanded);
     %BACKENDS{$backend}($ast, $runtime);
+    exit($runtime.exit-code);
 }
 
 multi MAIN($path, Str :$backend = "default") {

--- a/lib/_007/Builtins.pm6
+++ b/lib/_007/Builtins.pm6
@@ -2,6 +2,10 @@ use _007::Val;
 use _007::Q;
 use _007::OpScope;
 
+class X::Control::Exit is Exception {
+    has Int $.exit-code;
+}
+
 sub wrap($_) {
     when Val | Q { $_ }
     when Nil  { NONE }
@@ -110,6 +114,11 @@ my @builtins =
         # implementation in Runtime.pm
     },
     type => -> $arg { Val::Type.of($arg.WHAT) },
+    exit => -> $int = Val::Int.new(:value(0)) {
+        assert-type(:value($int), :type(Val::Int), :operation<exit>);
+        my $exit-code = $int.value % 256;
+        die X::Control::Exit.new(:$exit-code);
+    },
 
     # OPERATORS (from loosest to tightest within each category)
 

--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -6,6 +6,7 @@ constant NO_OUTER = Val::Object.new;
 constant RETURN_TO = Q::Identifier.new(
     :name(Val::Str.new(:value("--RETURN-TO--"))),
     :frame(NONE));
+constant EXIT_SUCCESS = 0;
 
 class _007::Runtime {
     has $.input;
@@ -28,7 +29,7 @@ class _007::Runtime {
         $!say-builtin = builtins-pad().properties<say>;
         $!prompt-builtin = builtins-pad().properties<prompt>;
         $!exit-builtin = builtins-pad().properties<exit>;
-        $!exit-code = 0;
+        $!exit-code = EXIT_SUCCESS;
     }
 
     method run(Q::CompUnit $compunit) {

--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -15,8 +15,11 @@ class _007::Runtime {
     has $.builtin-frame;
     has $!say-builtin;
     has $!prompt-builtin;
+    has $!exit-builtin;
+    has $.exit-code;
 
     submethod BUILD(:$!input, :$!output) {
+        $!builtin-opscope = opscope();
         $!builtin-frame = Val::Object.new(:properties(
             :outer-frame(NO_OUTER),
             :pad(builtins-pad()))
@@ -24,7 +27,8 @@ class _007::Runtime {
         @!frames.push($!builtin-frame);
         $!say-builtin = builtins-pad().properties<say>;
         $!prompt-builtin = builtins-pad().properties<prompt>;
-        $!builtin-opscope = opscope();
+        $!exit-builtin = builtins-pad().properties<exit>;
+        $!exit-code = 0;
     }
 
     method run(Q::CompUnit $compunit) {
@@ -32,6 +36,9 @@ class _007::Runtime {
         CATCH {
             when X::Control::Return {
                 die X::ControlFlow::Return.new;
+            }
+            when X::Control::Exit {
+                $!exit-code = .exit-code;
             }
         }
     }
@@ -164,7 +171,7 @@ class _007::Runtime {
             my $paramcount = $c.parameterlist.parameters.elements.elems;
             my $argcount = @arguments.elems;
             die X::ParameterMismatch.new(:type<Sub>, :$paramcount, :$argcount)
-                unless $paramcount == $argcount;
+                unless $paramcount == $argcount || $c === $!exit-builtin && $argcount < 2;
         }
         if $c === $!prompt-builtin {
             $.output.print(@arguments[0].Str);

--- a/lib/_007/Test.pm6
+++ b/lib/_007/Test.pm6
@@ -94,6 +94,16 @@ sub throws-exception($program, $message, $desc = "MISSING TEST DESCRIPTION") is 
     flunk $desc;
 }
 
+sub has-exit-code($program, $expected-exit-code, $desc = "MISSING TEST DESCRIPTION") is export {
+    my $output = UnwantedOutput.new;
+    my $runtime = _007.runtime(:$output);
+    my $parser = _007.parser(:$runtime);
+    my $ast = $parser.parse($program);
+    $runtime.run($ast);
+
+    is $runtime.exit-code, $expected-exit-code, $desc;
+}
+
 sub emits-js($program, @expected-builtins, $expected, $desc = "MISSING TEST DESCRIPTION") is export {
     my $output = UnwantedOutput.new;
     my $runtime = _007.runtime(:$output);

--- a/t/builtins/funcs.t
+++ b/t/builtins/funcs.t
@@ -84,7 +84,7 @@ use _007::Test;
         exit(1);
         .
 
-    has-exit-code $program, 1, "exit with a paramter";
+    has-exit-code $program, 1, "exit with a parameter";
 }
 
 {

--- a/t/builtins/funcs.t
+++ b/t/builtins/funcs.t
@@ -71,4 +71,46 @@ use _007::Test;
     outputs $program, "007\n<func say(...args)>\n", "builtin func say() has varargs";
 }
 
+{
+    my $program = q:to/./;
+        exit();
+        .
+
+    has-exit-code $program, 0, "exit without a parameter";
+}
+
+{
+    my $program = q:to/./;
+        exit(1);
+        .
+
+    has-exit-code $program, 1, "exit with a paramter";
+}
+
+{
+    my $program = q:to/./;
+        exit(-1);
+        .
+
+    has-exit-code $program, 255, "exit is modulo 256";
+}
+
+{
+    my $program = q:to/./;
+        func foo() {
+            exit();
+            say("foo");
+        }
+
+        func bar() {
+            foo();
+            say("bar");
+        }
+
+        bar();
+        .
+
+    outputs $program, "", "nothing is run after exit()";
+}
+
 done-testing;


### PR DESCRIPTION
Immediately interrupts what the runtime is doing. Valid exit codes
are 0..255, as per Unix convention. The exit code parameter is
optional.