### PR TITLE
Make comparison ops nonassociative by default

### DIFF
--- a/lib/_007/Builtins.pm6
+++ b/lib/_007/Builtins.pm6
@@ -140,6 +140,7 @@ my @builtins =
             return wrap(equal-value($lhs, $rhs));
         },
         :qtype(Q::Infix::Eq),
+        :assoc<non>,
     ),
     'infix:!=' => op(
         sub ($lhs, $rhs) {

--- a/t/builtins/operators.t
+++ b/t/builtins/operators.t
@@ -434,11 +434,12 @@ use _007::Test;
 {
     my $program = q:to/./;
         say(1 == 2 != 3);
-        say(4 != 5 == 6);
         .
 
-    outputs $program, "True\nFalse\n",
-        "comparison operators evaluate from left to right";
+    parse-error
+        $program,
+        X::Op::Nonassociative,
+        "comparison operators are nonassociative";
 }
 
 {
@@ -605,10 +606,11 @@ use _007::Test;
 {
     my $program = q:to/./;
         say("a" == "a" ~~ Bool);
-        say(7 ~~ Int == True);
         .
 
-    outputs $program, "True\nTrue\n", "infix:<~~> has the tightness of a comparison operator";
+    parse-error $program,
+        X::Op::Nonassociative,
+        "infix:<~~> has the tightness of a comparison operator (and so is nonassociative)";
 }
 
 {


### PR DESCRIPTION
Closes #396.