### PR TITLE
Introduce 'export' on 'func'/'macro'/'my'

### DIFF
--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -50,12 +50,13 @@ grammar _007::Parser::Syntax {
 
     proto token statement {*}
     token statement:expr {
+        $<export>=(export \s+)?
         <!before <!before '{{{'> '{'>   # } }}}, you're welcome vim
         <EXPR>
     }
     token statement:block { <pblock> }
     rule statement:func-or-macro {
-        $<routine>=(func|macro)» [<identifier> || <.panic("identifier")>]
+        [export\s+]?$<routine>=(func|macro)» [<identifier> || <.panic("identifier")>]
         :my $*in_routine = True;
         {
             declare($<routine> eq "func"

--- a/t/features/export.t
+++ b/t/features/export.t
@@ -1,0 +1,57 @@
+use v6;
+use Test;
+use _007::Test;
+
+{
+    my $program = q:to/./;
+        export func greet(name) {
+            say("Good evening, Mr " ~ name);
+        }
+        greet("Bond");
+        .
+
+    outputs $program, "Good evening, Mr Bond\n", "export syntax works for functions";
+}
+
+{
+    my $program = q:to/./;
+        export macro moo() {
+            say("Macro!");
+        }
+        moo();
+        .
+
+    outputs $program, "Macro!\n", "export syntax works for macros";
+}
+
+{
+    my $program = q:to/./;
+        export my name = "Bond";
+
+        say(name);
+        .
+
+    outputs $program, "Bond\n", "export syntax works for 'my' variables";
+}
+
+{
+    my $program = q:to/./;
+        export 2 + my name = "Bond";
+        .
+
+    parse-error $program,
+        X::Export::Nothing,
+        "export syntax is not allowed if 'my' variable is not on the left";
+}
+
+{
+    my $program = q:to/./;
+        export "but there was nothing there to export";
+        .
+
+    parse-error $program,
+        X::Export::Nothing,
+        "export syntax is not allowed if the 'my' variable is missing";
+}
+
+done-testing;


### PR DESCRIPTION
This keyword doesn't have any semantics at all yet, since we haven't
started implementing modules, not even behind a feature flag. The
idea to have this keyword now is to be able to write 007 code that's
closer to what modules will eventually look like when we do have
them. Less to change to make them work.

To be extra safe, and avoid having to break backwards compatibility
later, we make sure that if an expression is exported, then it has
a leftmost `my` to export.

Closes #404.