### PR TITLE
Make Travis run feature-flag tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: perl6
 sudo: false
 perl6:
   - latest
+env:
+  - FLAG_007_REGEX=1 FLAG_007_CLASS=1


### PR DESCRIPTION
This PR should probably be coordinated with #423, which introduces the `FLAG_007_DOCS` environment variable. I have a feeling that the combination of this PR and that one will fail, so please rebase whichever one merges second on the one that merges first.

Closes #422.