### PR TITLE
Implement flatMap for Array

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,7 @@
       }
     </style>
   </head>
-  <body class="checksum-dd911e">
+  <body class="checksum-aad523">
 <a href="https://github.com/masak/007"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 <div class="container">
 <p>This documentation has four parts:</p>

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1099,22 +1099,8 @@ Here's how an implementation of `infix:<xx>` might look:
 
 ```_007
 macro infix:<xx>(left, right) is equiv(infix:<*>) {
-    func flatten(array) {
-        my result = [];
-        for array -> elem {
-            if elem ~~ Array {
-                result = result.concat(elem);
-            } else {
-                result.push(elem);
-            }
-        }
-        return result;
-    }
-
     return quasi {
-        flatten((^{{{right}}}).map(func(_) {
-            return {{{left}}};
-        }))
+        (^{{{right}}}).flatMap(func(_) { {{{left}}} })
     }
 }
 ```

--- a/examples/x-and-xx.007
+++ b/examples/x-and-xx.007
@@ -1,20 +1,6 @@
 macro infix:<xx>(left, right) is equiv(infix:<*>) {
-    func flatten(array) {
-        my result = [];
-        for array -> elem {
-            if elem ~~ Array {
-                result = result.concat(elem);
-            } else {
-                result.push(elem);
-            }
-        }
-        return result;
-    }
-
     return quasi {
-        flatten((^{{{right}}}).map(func(_) {
-            return {{{left}}};
-        }))
+        (^{{{right}}}).flatMap(func(_) { {{{left}}} })
     }
 }
 

--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -460,6 +460,21 @@ class _007::Runtime {
                 return Val::Array.new(:@elements);
             });
         }
+        elsif $obj ~~ Val::Array && $propname eq "flatMap" {
+            return builtin(sub flatMap($fn) {
+                my @elements;
+                for $obj.elements -> $e {
+                    my $r = self.call($fn, [$e]);
+                    if $r ~~ Val::Array {
+                        @elements.push(|$r.elements);
+                    }
+                    else {
+                        @elements.push($r);
+                    }
+                }
+                return Val::Array.new(:@elements);
+            });
+        }
         elsif $obj ~~ Val::Array && $propname eq "push" {
             return builtin(sub push($newelem) {
                 $obj.elements.push($newelem);

--- a/t/builtins/methods.t
+++ b/t/builtins/methods.t
@@ -202,6 +202,28 @@ use _007::Test;
 
 {
     my $program = q:to/./;
+        func f(n) { [n * 2, n * 2 + 1] }
+        my a = [1, 2, 3];
+        say(a.flatMap(f));
+        say(a);
+        .
+
+    outputs $program, "[2, 3, 4, 5, 6, 7]\n[1, 2, 3]\n", "flatMap() works like map() but flattens one layer of array";
+}
+
+{
+    my $program = q:to/./;
+        func f(n) { ~n }
+        my a = [1, 2, 3];
+        say(a.flatMap(f));
+        say(a);
+        .
+
+    outputs $program, qq!["1", "2", "3"]\n[1, 2, 3]\n!, "flatMap() does nothing if there's no array to remove";
+}
+
+{
+    my $program = q:to/./;
         macro so_hygienic() {
             my x = "yay, clean!";
             return quasi {


### PR DESCRIPTION
It seems an obscure method to have as a builtin, but we were already using it in `examples/x-and-xx.007`, one of the "new" example files that actually uses a macro. So it felt worth its weight to fold that into the builtins.

Closes #442.