### PR TITLE
Lowercase 'true', 'false', and 'none'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,7 @@
       }
     </style>
   </head>
-  <body class="checksum-7ee3b2">
+  <body class="checksum-c37908">
 <a href="https://github.com/masak/007"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 <div class="container">
 <p>This documentation has four parts:</p>
@@ -107,7 +107,7 @@ say(&quot;Now my name is &quot;, name);  # &quot;Now my name is Mr. Smith&quot;<
 </blockquote>
 <p>That's all there is to variables; they are meant to be predictable and straightforward. Later, when writing macros has richer demands on variables, 007's <a href="#evaluating-expressions">location protocol</a> will allow us to manipulate variables more finely, controlling exactly when to read and/or assign to them.</p>
 <p>In 007, these &quot;scalar value&quot; types are built in:</p>
-<pre><code>None          NoneType
+<pre><code>none          NoneType
 false         Bool
 42            Int
 &quot;Bond&quot;        Str</code></pre>
@@ -126,7 +126,7 @@ termish := &lt;prefix&gt;* &lt;term&gt; &lt;postfix&gt;*</code></pre>
 <p><strong>Arithmetic</strong>. The infix operators <code>+ - * %</code> work as you'd expect. <code>%%</code> tests for divisibility, so it returns <code>true</code> whenever <code>%</code> returns <code>0</code>. <code>divmod</code> does an integer division resulting in a tuple <code>(q, r)</code> where <code>q</code> is the quotient and <code>r</code> is the reminder.</p>
 <p><strong>String building</strong>. You can concatenate strings with <code>~</code>. (To concatenate arrays, use the Array method <code>.concat</code>.)</p>
 <p><strong>Equality, comparison and matching</strong>. The operators <code>==</code> and <code>!=</code> checks whether values are equal or unequal. <code>&lt; &lt;= &gt; &gt;=</code> compare ordered types like integers or strings. <code>~~ !~~</code> match a value against a type.</p>
-<p><strong>Logical connectives</strong>. The infixes <code>||</code> and <code>&amp;&amp;</code> allow you to combine boolean (or really, any) values. Furthermore, <code>//</code> allows you to replace <code>None</code> values with a default. (All of these operators are short-circuiting. See the individual operators for more information.)</p>
+<p><strong>Logical connectives</strong>. The infixes <code>||</code> and <code>&amp;&amp;</code> allow you to combine boolean (or really, any) values. Furthermore, <code>//</code> allows you to replace <code>none</code> values with a default. (All of these operators are short-circuiting. See the individual operators for more information.)</p>
 <p><strong>Postfixes</strong>. The postfixes are <code>[]</code> for indexing, <code>()</code> for calls, and <code>.</code> for property lookup.</p>
 <p><strong>Conversion prefixes</strong>. The prefixes <code>+ -</code> convert to integers, <code>~</code> converts to a string, and <code>? !</code> convert to booleans. The prefix <code>^</code> turns an integer <code>n</code> into an array <code>[0, 1, 2, .., n - 1]</code>.</p>
 <p>Each operator has a built-in precedence which governs the order in which the operators are evaluated. This can be more clearly seen by pretending that the parser groups subexpressions by inserting parentheses around the tighter operators:</p>
@@ -208,7 +208,7 @@ func f2() {};   say(&quot;hi!&quot;)      # OK
 func f3() {}    say(&quot;oh noes&quot;)  # not ok</code></pre>
 <h3 id="block-statements">Block statements</h3>
 <p>007 has <code>if</code> statements, <code>while</code> loops and <code>for</code> loops by default. This example probably won't look too surprising to anyone who has seen C-like syntax before:</p>
-<pre class="_007"><code>my array = [5, func() { say(&quot;OH HAI&quot;) }, None];
+<pre class="_007"><code>my array = [5, func() { say(&quot;OH HAI&quot;) }, none];
 for array -&gt; e {
     if e ~~ Int {
         while e &gt; 0 {
@@ -242,7 +242,7 @@ for array -&gt; e {
 }
 
 say(&quot;3 + 4 = &quot;, add(3, 4));</code></pre>
-<p>The <code>return</code> statement immediately returns out of a function, optionally with a value. If no value is supplied (as in <code>return;</code>), the value <code>None</code> is returned. Implicit returns are OK too; the statement in the <code>add</code> function above could have been written as just <code>n1 + n2;</code> because it's last in the function.</p>
+<p>The <code>return</code> statement immediately returns out of a function, optionally with a value. If no value is supplied (as in <code>return;</code>), the value <code>none</code> is returned. Implicit returns are OK too; the statement in the <code>add</code> function above could have been written as just <code>n1 + n2;</code> because it's last in the function.</p>
 <p>When defined using a function statement, it's also allowed to call the function <em>before</em> its definition. (This is not true for any other type of defined thing in 007.)</p>
 <pre class="_007"><code>whoa();     # Amazingly, this works!
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,7 @@
       }
     </style>
   </head>
-  <body class="checksum-c37908">
+  <body class="checksum-a04500">
 <a href="https://github.com/masak/007"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 <div class="container">
 <p>This documentation has four parts:</p>
@@ -107,7 +107,7 @@ say(&quot;Now my name is &quot;, name);  # &quot;Now my name is Mr. Smith&quot;<
 </blockquote>
 <p>That's all there is to variables; they are meant to be predictable and straightforward. Later, when writing macros has richer demands on variables, 007's <a href="#evaluating-expressions">location protocol</a> will allow us to manipulate variables more finely, controlling exactly when to read and/or assign to them.</p>
 <p>In 007, these &quot;scalar value&quot; types are built in:</p>
-<pre><code>none          NoneType
+<pre><code>none          None
 false         Bool
 42            Int
 &quot;Bond&quot;        Str</code></pre>
@@ -357,7 +357,7 @@ BEGIN my AlphaColor = Type(
     fields: [{ name: &quot;alpha&quot; }],
 );</code></pre>
 <p>(Note how <code>self</code> has been made an explicit parameter along the way.)</p>
-<p><code>NoneType</code>, <code>Int</code>, <code>Str</code>, <code>Bool</code>, <code>Array</code>, <code>Tuple</code>, <code>Dict</code>, <code>Regex</code>, <code>Symbol</code>, and <code>Type</code> are all built-in types in 007. Besides that, there are all the types in <a href="#the-q-hierarchy">the <code>Q</code> hierarchy</a>, used to reasoning about program structure. There are also a number of exception types, under the <code>X</code> hierarchy.</p>
+<p><code>None</code>, <code>Int</code>, <code>Str</code>, <code>Bool</code>, <code>Array</code>, <code>Tuple</code>, <code>Dict</code>, <code>Regex</code>, <code>Symbol</code>, and <code>Type</code> are all built-in types in 007. Besides that, there are all the types in <a href="#the-q-hierarchy">the <code>Q</code> hierarchy</a>, used to reasoning about program structure. There are also a number of exception types, under the <code>X</code> hierarchy.</p>
 <p>Here's an example involving a custom <code>Range</code> class, which we'll use later to also declare custom range operators:</p>
 <pre class="_007"><code>class Range {
     @get has min;

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,7 @@
       }
     </style>
   </head>
-  <body class="checksum-aad523">
+  <body class="checksum-7ee3b2">
 <a href="https://github.com/masak/007"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 <div class="container">
 <p>This documentation has four parts:</p>
@@ -108,7 +108,7 @@ say(&quot;Now my name is &quot;, name);  # &quot;Now my name is Mr. Smith&quot;<
 <p>That's all there is to variables; they are meant to be predictable and straightforward. Later, when writing macros has richer demands on variables, 007's <a href="#evaluating-expressions">location protocol</a> will allow us to manipulate variables more finely, controlling exactly when to read and/or assign to them.</p>
 <p>In 007, these &quot;scalar value&quot; types are built in:</p>
 <pre><code>None          NoneType
-False         Bool
+false         Bool
 42            Int
 &quot;Bond&quot;        Str</code></pre>
 <p>And these &quot;container&quot; types:</p>
@@ -123,7 +123,7 @@ termish := &lt;prefix&gt;* &lt;term&gt; &lt;postfix&gt;*</code></pre>
 <p>You can have whitespace before or after terms and operators, and it largely doesn't change the meaning of the program. The recommended style is to use whitespace around infixes, but not after prefixes or before postfixes.</p>
 <p>007 has 28 built-in operators. Here we describe them by group. (These are just short descriptions. For more detail, see each individual operator in the API docs.)</p>
 <p><strong>Assignment</strong>. The <code>x = 42</code> expression assigns the value <code>42</code> to the variable <code>x</code>.</p>
-<p><strong>Arithmetic</strong>. The infix operators <code>+ - * %</code> work as you'd expect. <code>%%</code> tests for divisibility, so it returns <code>True</code> whenever <code>%</code> returns <code>0</code>. <code>divmod</code> does an integer division resulting in a tuple <code>(q, r)</code> where <code>q</code> is the quotient and <code>r</code> is the reminder.</p>
+<p><strong>Arithmetic</strong>. The infix operators <code>+ - * %</code> work as you'd expect. <code>%%</code> tests for divisibility, so it returns <code>true</code> whenever <code>%</code> returns <code>0</code>. <code>divmod</code> does an integer division resulting in a tuple <code>(q, r)</code> where <code>q</code> is the quotient and <code>r</code> is the reminder.</p>
 <p><strong>String building</strong>. You can concatenate strings with <code>~</code>. (To concatenate arrays, use the Array method <code>.concat</code>.)</p>
 <p><strong>Equality, comparison and matching</strong>. The operators <code>==</code> and <code>!=</code> checks whether values are equal or unequal. <code>&lt; &lt;= &gt; &gt;=</code> compare ordered types like integers or strings. <code>~~ !~~</code> match a value against a type.</p>
 <p><strong>Logical connectives</strong>. The infixes <code>||</code> and <code>&amp;&amp;</code> allow you to combine boolean (or really, any) values. Furthermore, <code>//</code> allows you to replace <code>None</code> values with a default. (All of these operators are short-circuiting. See the individual operators for more information.)</p>
@@ -224,7 +224,7 @@ for array -&gt; e {
     }
 }</code></pre>
 <p>The normal block statements all require blocks with curly braces (<code>{}</code>) — there's no blockless form. Unlike C/Java/JavaScript/C# but like Python, parentheses (<code>()</code>) are optional around expressions after <code>if</code>, <code>for</code> and <code>while</code>.</p>
-<p>The <code>if</code> and <code>while</code> statements evaluate their expression and runs their block if the resulting value is <code>True</code>, possibly after coercing to <code>Bool</code>. (We sometimes refer to a value that is <code>True</code> when coerced to <code>Bool</code> as <em>truthy</em>, and the other values as <em>falsy</em>.) Several other mechanisms in 007, such as <code>&amp;&amp;</code> and the <code>.filter</code> method, accept these &quot;generalized <code>Bool</code> values&quot;.</p>
+<p>The <code>if</code> and <code>while</code> statements evaluate their expression and runs their block if the resulting value is <code>true</code>, possibly after coercing to <code>Bool</code>. (We sometimes refer to a value that is <code>true</code> when coerced to <code>Bool</code> as <em>truthy</em>, and the other values as <em>falsy</em>.) Several other mechanisms in 007, such as <code>&amp;&amp;</code> and the <code>.filter</code> method, accept these &quot;generalized <code>Bool</code> values&quot;.</p>
 <p>The optional <code>-&gt; e</code> syntax is a <em>block parameter</em>, and is a way to pass each element as a lexical variable into the block. Although the most natural fit is a <code>for</code> loop, it also works consistently for <code>while</code> loops and <code>if</code> statements (including the <code>else if</code> and <code>else</code> blocks). All these blocks accept at most one parameter.</p>
 <h3 id="exceptional-control-flow">Exceptional control flow</h3>
 <blockquote class="future">

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -101,7 +101,7 @@ variables more finely, controlling exactly when to read and/or assign to them.
 
 In 007, these "scalar value" types are built in:
 
-    None          NoneType
+    none          NoneType
     false         Bool
     42            Int
     "Bond"        Str
@@ -148,7 +148,7 @@ whether values are equal or unequal. `< <= > >=` compare ordered types like
 integers or strings. `~~ !~~` match a value against a type.
 
 **Logical connectives**. The infixes `||` and `&&` allow you to combine boolean
-(or really, any) values. Furthermore, `//` allows you to replace `None` values
+(or really, any) values. Furthermore, `//` allows you to replace `none` values
 with a default. (All of these operators are short-circuiting. See the
 individual operators for more information.)
 
@@ -227,7 +227,7 @@ func f3() {}    say("oh noes")  # not ok
 probably won't look too surprising to anyone who has seen C-like syntax before:
 
 ```_007
-my array = [5, func() { say("OH HAI") }, None];
+my array = [5, func() { say("OH HAI") }, none];
 for array -> e {
     if e ~~ Int {
         while e > 0 {
@@ -294,7 +294,7 @@ say("3 + 4 = ", add(3, 4));
 ```
 
 The `return` statement immediately returns out of a function, optionally with a
-value. If no value is supplied (as in `return;`), the value `None` is returned.
+value. If no value is supplied (as in `return;`), the value `none` is returned.
 Implicit returns are OK too; the statement in the `add` function above could
 have been written as just `n1 + n2;` because it's last in the function.
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -102,7 +102,7 @@ variables more finely, controlling exactly when to read and/or assign to them.
 In 007, these "scalar value" types are built in:
 
     None          NoneType
-    False         Bool
+    false         Bool
     42            Int
     "Bond"        Str
 
@@ -136,7 +136,7 @@ docs.)
 `x`.
 
 **Arithmetic**. The infix operators `+ - * %` work as you'd expect. `%%` tests
-for divisibility, so it returns `True` whenever `%` returns `0`. `divmod` does
+for divisibility, so it returns `true` whenever `%` returns `0`. `divmod` does
 an integer division resulting in a tuple `(q, r)` where `q` is the quotient and
 `r` is the reminder.
 
@@ -250,8 +250,8 @@ parentheses (`()`) are optional around expressions after `if`, `for` and
 `while`.
 
 The `if` and `while` statements evaluate their expression and runs their block
-if the resulting value is `True`, possibly after coercing to `Bool`. (We
-sometimes refer to a value that is `True` when coerced to `Bool` as _truthy_,
+if the resulting value is `true`, possibly after coercing to `Bool`. (We
+sometimes refer to a value that is `true` when coerced to `Bool` as _truthy_,
 and the other values as _falsy_.) Several other mechanisms in 007, such as `&&`
 and the `.filter` method, accept these "generalized `Bool` values".
 
@@ -1213,11 +1213,11 @@ Consider this macro:
 
 ```_007
 macro onlyOnce(expr) {
-    my alreadyRan = False;
+    my alreadyRan = false;
     return quasi {
         if !alreadyRan {
             {{{expr}}};
-            alreadyRan = True;
+            alreadyRan = true;
         }
     };
 }
@@ -1261,14 +1261,14 @@ Here's how we can simply implement this macro:
 
 ```_007
 macro infix:<ff>(lhs, rhs) {
-    my active = False;
+    my active = false;
     return quasi {
         if {{{lhs}}} {
-            active = True;
+            active = true;
         }
         my result = active;
         if {{{rhs}}} {
-            active = False;
+            active = false;
         }
         result;
     };
@@ -1288,14 +1288,14 @@ macro infix:<ff>(lhs, rhs) {
     return quasi {
         my COMPILING.{{{Q.Identifier @ active}}};
         once {
-            COMPILING.{{{Q.Identifier @ active}}} = False;
+            COMPILING.{{{Q.Identifier @ active}}} = false;
         }
         if {{{lhs}}} {
-            COMPILING.{{{Q.Identifier @ active}}} = True;
+            COMPILING.{{{Q.Identifier @ active}}} = true;
         }
         my result = COMPILING.{{{Q.Identifier @ active}}};
         if {{{rhs}}} {
-            COMPILING.{{{Q.Identifier @ active}}} = False;
+            COMPILING.{{{Q.Identifier @ active}}} = false;
         }
         result;
     };

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -101,7 +101,7 @@ variables more finely, controlling exactly when to read and/or assign to them.
 
 In 007, these "scalar value" types are built in:
 
-    none          NoneType
+    none          None
     false         Bool
     42            Int
     "Bond"        Str
@@ -541,7 +541,7 @@ BEGIN my AlphaColor = Type(
 
 (Note how `self` has been made an explicit parameter along the way.)
 
-`NoneType`, `Int`, `Str`, `Bool`, `Array`, `Tuple`, `Dict`, `Regex`, `Symbol`,
+`None`, `Int`, `Str`, `Bool`, `Array`, `Tuple`, `Dict`, `Regex`, `Symbol`,
 and `Type` are all built-in types in 007. Besides that, there are all the types
 in [the `Q` hierarchy](#the-q-hierarchy), used to reasoning about program
 structure. There are also a number of exception types, under the `X` hierarchy.

--- a/examples/in.007
+++ b/examples/in.007
@@ -2,10 +2,10 @@ func infix:<in>(value, container) {
     if container ~~ Array {
         for container -> elem {
             if elem == value {
-                return True;
+                return true;
             }
         }
-        return False;
+        return false;
     }
     else if container ~~ Object {
         return container.has(value);
@@ -24,10 +24,10 @@ func infix:<not in>(value, container) {
     if container ~~ Array {
         for container -> elem {
             if elem == value {
-                return False;
+                return false;
             }
         }
-        return True;
+        return true;
     }
     else if container ~~ Object {
         return !container.has(value);
@@ -42,16 +42,16 @@ func infix:<not in>(value, container) {
     }
 }
 
-say("foo" in { foo: 42 });              # True
-say("bar" in { foo: 42 });              # False
-say(3 in [1, 2, 3, 4]);                 # True
-say(8 in [1, 2, 3, 4]);                 # False
-say("foo" in "foolish");                # True
-say("I" in "team");                     # False
+say("foo" in { foo: 42 });              # true
+say("bar" in { foo: 42 });              # false
+say(3 in [1, 2, 3, 4]);                 # true
+say(8 in [1, 2, 3, 4]);                 # false
+say("foo" in "foolish");                # true
+say("I" in "team");                     # false
 
-say("job" not in { name: "James" });    # True
-say("name" not in { name: "James" });   # False
-say("d" not in ["a", "b", "c"]);        # True
-say("b" not in ["a", "b", "c"]);        # False
-say("we" not in "Kansas");              # True
-say("pi" not in "pie");                 # False
+say("job" not in { name: "James" });    # true
+say("name" not in { name: "James" });   # false
+say("d" not in ["a", "b", "c"]);        # true
+say("b" not in ["a", "b", "c"]);        # false
+say("we" not in "Kansas");              # true
+say("pi" not in "pie");                 # false

--- a/lib/_007/Equal.pm6
+++ b/lib/_007/Equal.pm6
@@ -3,7 +3,7 @@ use _007::Q;
 
 # These multis are used below by infix:<==> and infix:<!=>
 multi equal-value($, $) is export { False }
-multi equal-value(Val::NoneType, Val::NoneType) { True }
+multi equal-value(Val::None, Val::None) { True }
 multi equal-value(Val::Bool $l, Val::Bool $r) { $l.value == $r.value }
 multi equal-value(Val::Int $l, Val::Int $r) { $l.value == $r.value }
 multi equal-value(Val::Str $l, Val::Str $r) { $l.value eq $r.value }

--- a/lib/_007/Parser/Actions.pm6
+++ b/lib/_007/Parser/Actions.pm6
@@ -452,7 +452,7 @@ class _007::Parser::Actions {
             :name(Val::Str.new(:value("prefix:$op"))),
             :frame($*runtime.current-frame),
         );
-        make $*parser.opscope.ops<prefix>{$op}.new(:$identifier, :operand(Val::NoneType));
+        make $*parser.opscope.ops<prefix>{$op}.new(:$identifier, :operand(Val::None));
     }
 
     method prefix-unquote($/) {

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -190,8 +190,8 @@ grammar _007::Parser::Syntax {
 
     proto token term {*}
     token term:none { None» }
-    token term:false { False» }
-    token term:true { True» }
+    token term:false { false» }
+    token term:true { true» }
     token term:int { \d+ }
     token term:array { '[' ~ ']' [[<.ws> <EXPR>]* %% [\h* ','] <.ws>] }
     token term:str { <str> }

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -189,7 +189,7 @@ grammar _007::Parser::Syntax {
     }
 
     proto token term {*}
-    token term:none { None» }
+    token term:none { none» }
     token term:false { false» }
     token term:true { true» }
     token term:int { \d+ }

--- a/lib/_007/Q.pm6
+++ b/lib/_007/Q.pm6
@@ -378,7 +378,7 @@ class Q::Term::Func does Q::Term does Q::Declaration {
     method attribute-order { <identifier traitlist block> }
 
     method eval($runtime) {
-        my $name = $.identifier ~~ Val::NoneType
+        my $name = $.identifier ~~ Val::None
             ?? Val::Str.new(:value(""))
             !! $.identifier.name;
         return Val::Func.new(
@@ -483,7 +483,7 @@ class Q::Infix::Or is Q::Infix {
 class Q::Infix::DefinedOr is Q::Infix {
     method eval($runtime) {
         my $l = $.lhs.eval($runtime);
-        return $l !~~ Val::NoneType
+        return $l !~~ Val::None
             ?? $l
             !! $.rhs.eval($runtime);
     }
@@ -908,7 +908,7 @@ class Q::Statement::Return does Q::Statement {
     has $.expr = NONE;
 
     method run($runtime) {
-        my $value = $.expr ~~ Val::NoneType ?? $.expr !! $.expr.eval($runtime);
+        my $value = $.expr ~~ Val::None ?? $.expr !! $.expr.eval($runtime);
         my $frame = $runtime.get-var("--RETURN-TO--");
         die X::Control::Return.new(:$value, :$frame);
     }
@@ -922,7 +922,7 @@ class Q::Statement::Throw does Q::Statement {
     has $.expr = NONE;
 
     method run($runtime) {
-        my $value = $.expr ~~ Val::NoneType
+        my $value = $.expr ~~ Val::None
             ?? Val::Exception.new(:message(Val::Str.new(:value("Died"))))
             !! $.expr.eval($runtime);
         die X::TypeCheck.new(:got($value), :excpected(Val::Exception))

--- a/lib/_007/Q.pm6
+++ b/lib/_007/Q.pm6
@@ -112,7 +112,7 @@ role Q::Term does Q::Expr {
 ### ### Q::Literal
 ###
 ### A literal; a constant value written out explicitly in the program, such as
-### `None`, `true`, `5`, or `"James Bond"`.
+### `none`, `true`, `5`, or `"James Bond"`.
 ###
 ### Compound values such as arrays and objects are considered terms but not
 ### literals.
@@ -122,7 +122,7 @@ role Q::Literal does Q::Term {
 
 ### ### Q::Literal::None
 ###
-### The `None` literal.
+### The `none` literal.
 ###
 class Q::Literal::None does Q::Literal {
     method eval($) { NONE }
@@ -478,7 +478,7 @@ class Q::Infix::Or is Q::Infix {
 ### ### Q::Infix::DefinedOr
 ###
 ### A short-circuiting "defined-or" operator. Evaluates its
-### right-hand side only if the left-hand side is `None`.
+### right-hand side only if the left-hand side is `none`.
 ###
 class Q::Infix::DefinedOr is Q::Infix {
     method eval($runtime) {

--- a/lib/_007/Q.pm6
+++ b/lib/_007/Q.pm6
@@ -112,7 +112,7 @@ role Q::Term does Q::Expr {
 ### ### Q::Literal
 ###
 ### A literal; a constant value written out explicitly in the program, such as
-### `None`, `True`, `5`, or `"James Bond"`.
+### `None`, `true`, `5`, or `"James Bond"`.
 ###
 ### Compound values such as arrays and objects are considered terms but not
 ### literals.
@@ -130,7 +130,7 @@ class Q::Literal::None does Q::Literal {
 
 ### ### Q::Literal::Bool
 ###
-### A boolean literal; either `True` or `False`.
+### A boolean literal; either `true` or `false`.
 ###
 class Q::Literal::Bool does Q::Literal {
     has Val::Bool $.value;

--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -128,7 +128,7 @@ class _007::Runtime {
     }
 
     method !maybe-find-pad(Str $symbol, $frame is copy) {
-        if $frame ~~ Val::NoneType {    # XXX: make a `defined` method on NoneType so we can use `//`
+        if $frame ~~ Val::None {    # XXX: make a `defined` method on None so we can use `//`
             $frame = self.current-frame;
         }
         repeat until $frame === NO_OUTER {
@@ -142,7 +142,7 @@ class _007::Runtime {
 
     method put-var(Q::Identifier $identifier, $value) {
         my $name = $identifier.name.value;
-        my $frame = $identifier.frame ~~ Val::NoneType
+        my $frame = $identifier.frame ~~ Val::None
             ?? self.current-frame
             !! $identifier.frame;
         my $pad = self!find-pad($name, $frame);
@@ -162,7 +162,7 @@ class _007::Runtime {
 
     method declare-var(Q::Identifier $identifier, $value?) {
         my $name = $identifier.name.value;
-        my Val::Object $frame = $identifier.frame ~~ Val::NoneType
+        my Val::Object $frame = $identifier.frame ~~ Val::None
             ?? self.current-frame
             !! $identifier.frame;
         $frame.properties<pad>.properties{$name} = $value // NONE;

--- a/lib/_007/Val.pm6
+++ b/lib/_007/Val.pm6
@@ -45,7 +45,7 @@ role Val {
 ###
 ### The value `None` is falsy, stringifies to `None`, and doesn't numify.
 ###
-###     say(!!None);        # --> `False`
+###     say(!!None);        # --> `false`
 ###     say(~None);         # --> `None`
 ###     say(+None);         # <ERROR X::TypeCheck>
 ###
@@ -65,14 +65,14 @@ constant NONE is export = Val::NoneType.new;
 
 ### ### Bool
 ###
-### A type with two values, `True` and `False`. These are often the result
+### A type with two values, `true` and `false`. These are often the result
 ### of comparisons or match operations, such as `infix:<==>` or `infix:<~~>`.
 ###
-###     say(2 + 2 == 5);        # --> `False`
-###     say(7 ~~ Int);          # --> `True`
+###     say(2 + 2 == 5);        # --> `false`
+###     say(7 ~~ Int);          # --> `true`
 ###
 ### In 007 as in many other dynamic languages, it's not necessary to use
-### `True` or `False` values directly in conditions such as `if` statements
+### `true` or `false` values directly in conditions such as `if` statements
 ### or `while` loops. *Any* value can be used, and there's always a way
 ### for each type to convert any of its values to a boolean value:
 ###
@@ -85,13 +85,13 @@ constant NONE is export = Val::NoneType.new;
 ###         }
 ###     }
 ###     check(None);            # --> `falsy`
-###     check(False);           # --> `falsy`
+###     check(false);           # --> `falsy`
 ###     check(0);               # --> `falsy`
 ###     check("");              # --> `falsy`
 ###     check([]);              # --> `falsy`
 ###     check({});              # --> `falsy`
 ###     # all other values are truthy
-###     check(True);            # --> `truthy`
+###     check(true);            # --> `truthy`
 ###     check(42);              # --> `truthy`
 ###     check("James");         # --> `truthy`
 ###     check([0, 0, 7]);       # --> `truthy`
@@ -171,7 +171,7 @@ class Val::Int does Val {
 ###     say("abcd".substr(1, 2));               # --> `bc`
 ###     say("abcd".prefix(3));                  # --> `abc`
 ###     say("abcd".suffix(2));                  # --> `cd`
-###     say("James Bond".contains("s B"));      # --> `True`
+###     say("James Bond".contains("s B"));      # --> `true`
 ###     say("James".charat(2));                 # --> `m`
 ###
 class Val::Str does Val {
@@ -191,15 +191,15 @@ class Val::Str does Val {
 ### A regex. As a runtime value, a regex is like a black box that can be put
 ### to work matching strings or parts of strings. Its main purpose is
 ### to let us know whether the string matches the pattern described in the
-### regex. In other words, it returns `True` or `False`.
+### regex. In other words, it returns `true` or `false`.
 ###
 ### (Regexes are currently under development, and are hidden behind a feature
 ### flag for the time being: `FLAG_007_REGEX`.)
 ###
 ### A few methods are defined on regexes:
 ###
-###     say(/"Bond"/.fullmatch("J. Bond"));     # --> `False`
-###     say(/"Bond"/.search("J. Bond"));        # --> `True`
+###     say(/"Bond"/.fullmatch("J. Bond"));     # --> `false`
+###     say(/"Bond"/.search("J. Bond"));        # --> `true`
 ###
 class Val::Regex does Val {
     # note: a regex should probably keep its lexpad or something to resolve calls&identifiers
@@ -420,10 +420,10 @@ our $global-object-id = 0;
 ###
 ###     my o1 = { foo: 42 };        # autoquoted key
 ###     my o2 = { "foo": 42 };      # string key
-###     say(o1 == o2);              # --> `True`
+###     say(o1 == o2);              # --> `true`
 ###     my foo = 42;
 ###     my o3 = { foo };            # property shorthand
-###     say(o1 == o3);              # --> `True`
+###     say(o1 == o3);              # --> `true`
 ###
 ###     my o4 = {
 ###         greet: func () {
@@ -435,7 +435,7 @@ our $global-object-id = 0;
 ###             return "hi!";
 ###         }
 ###     };
-###     say(o4.greet() == o5.greet());  # --> `True`
+###     say(o4.greet() == o5.greet());  # --> `true`
 ###
 ### All of the above will create objects of type `Object`, which is
 ### the topmost type in the type system. `Object` also has the special
@@ -478,9 +478,9 @@ our $global-object-id = 0;
 ###         foo: 42,
 ###         bar: None
 ###     };
-###     say(o11.has("foo"));        # --> `True`
-###     say(o11.has("bar"));        # --> `True`
-###     say(o11.has("bazinga"));    # --> `False`
+###     say(o11.has("foo"));        # --> `true`
+###     say(o11.has("bar"));        # --> `true`
+###     say(o11.has("bazinga"));    # --> `false`
 ###
 ### Note that the criterion is whether the *key* exists, not whether the
 ### corresponding value is defined.
@@ -492,8 +492,8 @@ our $global-object-id = 0;
 ###
 ###     my o12 = { foo: 5 };
 ###     my o13 = { foo: 5 };        # same key/value but different reference
-###     say(o12 == o13);            # --> `True`
-###     say(o12.id == o13.id);      # --> `False`
+###     say(o12 == o13);            # --> `true`
+###     say(o12.id == o13.id);      # --> `false`
 ###
 class Val::Object does Val {
     has %.properties{Str};
@@ -545,24 +545,24 @@ class Val::Object does Val {
 ### If you want to check whether a certain object is of a certain type,
 ### you can use the `infix:<~~>` operator:
 ###
-###     say(42 ~~ Int);         # --> `True`
-###     say(42 ~~ Str);         # --> `False`
+###     say(42 ~~ Int);         # --> `true`
+###     say(42 ~~ Str);         # --> `false`
 ###
 ### The `infix:<~~>` operator respects subtyping, so checking against a
-### wider type also gives a `True` result:
+### wider type also gives a `true` result:
 ###
 ###     my q = new Q.Literal.Int { value: 42 };
-###     say(q ~~ Q.Literal.Int);    # --> `True`
-###     say(q ~~ Q.Literal);        # --> `True`
-###     say(q ~~ Q);                # --> `True`
-###     say(q ~~ Int);              # --> `False`
+###     say(q ~~ Q.Literal.Int);    # --> `true`
+###     say(q ~~ Q.Literal);        # --> `true`
+###     say(q ~~ Q);                # --> `true`
+###     say(q ~~ Int);              # --> `false`
 ###
 ### If you want *exact* type matching (which isn't a very OO thing to want),
 ### consider using infix:<==> on the respective type objects instead:
 ###
 ###     my q = new Q.Literal.Str { value: "Bond" };
-###     say(type(q) == Q.Literal.Str);      # --> `True`
-###     say(type(q) == Q.Literal);          # --> `False`
+###     say(type(q) == Q.Literal.Str);      # --> `true`
+###     say(type(q) == Q.Literal);          # --> `false`
 ###
 class Val::Type does Val {
     has $.type;
@@ -685,7 +685,7 @@ class Val::Exception does Val {
 class Helper {
     our sub Str($_) {
         when Val::NoneType { "None" }
-        when Val::Bool { .value.Str }
+        when Val::Bool { .value.lc }
         when Val::Int { .value.Str }
         when Val::Str { .value }
         when Val::Regex { .quoted-Str }

--- a/lib/_007/Val.pm6
+++ b/lib/_007/Val.pm6
@@ -27,32 +27,32 @@ role Val {
 ### It is the value variables have that haven't been assigned to:
 ###
 ###     my empty;
-###     say(empty);         # --> `None`
+###     say(empty);         # --> `none`
 ###
 ### It is also the value returned from a subroutine that didn't explicitly
 ### return a value:
 ###
 ###     func noreturn() {
 ###     }
-###     say(noreturn());    # --> `None`
+###     say(noreturn());    # --> `none`
 ###
 ### Finally, it's found in various places in the Q hierarchy to indicate that
 ### a certain child element is not present. For example, an `if` statement
 ### doesn't always have an `else` statement. When it doesn't, the `.else`
-### property is set to `None`.
+### property is set to `none`.
 ###
 ###     say(type((quasi<Q.Statement> { if 1 {} }).else)); # --> `<type NoneType>`
 ###
-### The value `None` is falsy, stringifies to `None`, and doesn't numify.
+### The value `none` is falsy, stringifies to `none`, and doesn't numify.
 ###
-###     say(!!None);        # --> `false`
-###     say(~None);         # --> `None`
-###     say(+None);         # <ERROR X::TypeCheck>
+###     say(!!none);        # --> `false`
+###     say(~none);         # --> `none`
+###     say(+none);         # <ERROR X::TypeCheck>
 ###
-### Since `None` is often used as a default, there's an operator `infix:<//>`
-### that evaluates its right-hand side if it finds `None` on the left:
+### Since `none` is often used as a default, there's an operator `infix:<//>`
+### that evaluates its right-hand side if it finds `none` on the left:
 ###
-###     say(None // "default");     # --> `default`
+###     say(none // "default");     # --> `default`
 ###     say("value" // "default");  # --> `value`
 ###
 class Val::NoneType does Val {
@@ -84,7 +84,7 @@ constant NONE is export = Val::NoneType.new;
 ###             say("falsy");
 ###         }
 ###     }
-###     check(None);            # --> `falsy`
+###     check(none);            # --> `falsy`
 ###     check(false);           # --> `falsy`
 ###     check(0);               # --> `falsy`
 ###     check("");              # --> `falsy`
@@ -103,8 +103,8 @@ constant NONE is export = Val::NoneType.new;
 ###
 ###     say(1 || 2);            # --> `1`
 ###     say(1 && 2);            # --> `2`
-###     say(None && "!");       # --> `None`
-###     say(None || "!");       # --> `!`
+###     say(none && "!");       # --> `none`
+###     say(none || "!");       # --> `!`
 ###
 class Val::Bool does Val {
     has Bool $.value;
@@ -476,7 +476,7 @@ our $global-object-id = 0;
 ###
 ###     my o11 = {
 ###         foo: 42,
-###         bar: None
+###         bar: none
 ###     };
 ###     say(o11.has("foo"));        # --> `true`
 ###     say(o11.has("bar"));        # --> `true`
@@ -684,7 +684,7 @@ class Val::Exception does Val {
 
 class Helper {
     our sub Str($_) {
-        when Val::NoneType { "None" }
+        when Val::NoneType { "none" }
         when Val::Bool { .value.lc }
         when Val::Int { .value.Str }
         when Val::Str { .value }

--- a/lib/_007/Val.pm6
+++ b/lib/_007/Val.pm6
@@ -19,7 +19,7 @@ role Val {
     }
 }
 
-### ### NoneType
+### ### None
 ###
 ### A type with only one value, indicating the lack of a value where one was
 ### expected.
@@ -41,7 +41,7 @@ role Val {
 ### doesn't always have an `else` statement. When it doesn't, the `.else`
 ### property is set to `none`.
 ###
-###     say(type((quasi<Q.Statement> { if 1 {} }).else)); # --> `<type NoneType>`
+###     say(type((quasi<Q.Statement> { if 1 {} }).else)); # --> `<type None>`
 ###
 ### The value `none` is falsy, stringifies to `none`, and doesn't numify.
 ###
@@ -55,13 +55,13 @@ role Val {
 ###     say(none // "default");     # --> `default`
 ###     say("value" // "default");  # --> `value`
 ###
-class Val::NoneType does Val {
+class Val::None does Val {
     method truthy {
         False
     }
 }
 
-constant NONE is export = Val::NoneType.new;
+constant NONE is export = Val::None.new;
 
 ### ### Bool
 ###
@@ -527,7 +527,7 @@ class Val::Object does Val {
 ###     say(type({}));          # --> `<type Object>`
 ###     say(type(type({})));    # --> `<type Type>`
 ###
-### 007 comes with a number of built-in types: `NoneType`, `Bool`, `Int`,
+### 007 comes with a number of built-in types: `None`, `Bool`, `Int`,
 ### `Str`, `Array`, `Object`, `Regex`, `Type`, `Block`, `Sub`, `Macro`,
 ### and `Exception`.
 ###
@@ -593,7 +593,7 @@ class Val::Type does Val {
                 method ^name(\$) \{ "{$name}" \}
             \}]));
         }
-        elsif $.type ~~ Val::NoneType || $.type ~~ Val::Bool || is-role($.type) {
+        elsif $.type ~~ Val::None || $.type ~~ Val::Bool || is-role($.type) {
             die X::Uninstantiable.new(:$.name);
         }
         else {
@@ -684,7 +684,7 @@ class Val::Exception does Val {
 
 class Helper {
     our sub Str($_) {
-        when Val::NoneType { "none" }
+        when Val::None { "none" }
         when Val::Bool { .value.lc }
         when Val::Int { .value.Str }
         when Val::Str { .value }

--- a/t/backend/ast.t
+++ b/t/backend/ast.t
@@ -23,7 +23,7 @@ my $parser = _007.parser;
                             parameterlist: Q.ParameterList [],
                             statementlist: Q.StatementList []
                         },
-                        else: None
+                        else: none
                     }]
                 }
             }]

--- a/t/builtins/funcs.t
+++ b/t/builtins/funcs.t
@@ -20,10 +20,10 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(type(None));
+        say(type(none));
         .
 
-    outputs $program, "<type NoneType>\n", "None type() works";
+    outputs $program, "<type NoneType>\n", "none type() works";
 }
 
 {

--- a/t/builtins/funcs.t
+++ b/t/builtins/funcs.t
@@ -15,7 +15,7 @@ use _007::Test;
         say(type(prompt(">>> ")));
         .
 
-    outputs $program, ">>> \n<type NoneType>\n", "say() works";
+    outputs $program, ">>> \n<type None>\n", "say() works";
 }
 
 {
@@ -23,7 +23,7 @@ use _007::Test;
         say(type(none));
         .
 
-    outputs $program, "<type NoneType>\n", "none type() works";
+    outputs $program, "<type None>\n", "none type() works";
 }
 
 {

--- a/t/builtins/methods.t
+++ b/t/builtins/methods.t
@@ -320,7 +320,7 @@ use _007::Test;
         say(a.contains("8"));
         .
 
-    outputs $program, "True\nFalse\n", "contains() returns whether a string contains another";
+    outputs $program, "true\nfalse\n", "contains() returns whether a string contains another";
 }
 
 {
@@ -328,7 +328,7 @@ use _007::Test;
         say("foobar".contains("foo") ~~ Bool);
         .
 
-    outputs $program, "True\n", "contains() returns a Bool value";
+    outputs $program, "true\n", "contains() returns a Bool value";
 }
 
 {
@@ -397,7 +397,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(Bool.create([["value", False]]));
+        say(Bool.create([["value", false]]));
         .
 
     runtime-error $program, X::Uninstantiable, "can't instantiate a Bool";

--- a/t/builtins/methods.t
+++ b/t/builtins/methods.t
@@ -389,10 +389,10 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(NoneType.create([]));
+        say(None.create([]));
         .
 
-    runtime-error $program, X::Uninstantiable, "can't instantiate a NoneType";
+    runtime-error $program, X::Uninstantiable, "can't instantiate a None";
 }
 
 {

--- a/t/builtins/operators.t
+++ b/t/builtins/operators.t
@@ -61,7 +61,7 @@ use _007::Test;
         say(6 %% -2);
         .
 
-    outputs $program, "False\nTrue\nFalse\nTrue\n", "divisibility operator works";
+    outputs $program, "false\ntrue\nfalse\ntrue\n", "divisibility operator works";
 }
 
 {
@@ -119,7 +119,7 @@ use _007::Test;
         say(i1 == i2);
         .
 
-    outputs $program, "True\nFalse\n", "integer equality";
+    outputs $program, "true\nfalse\n", "integer equality";
 }
 
 {
@@ -130,7 +130,7 @@ use _007::Test;
         say(i1 != i2);
         .
 
-    outputs $program, "False\nTrue\n", "integer inequality";
+    outputs $program, "false\ntrue\n", "integer inequality";
 }
 
 {
@@ -141,7 +141,7 @@ use _007::Test;
         say(s1 == s2);
         .
 
-    outputs $program, "True\nFalse\n", "string equality";
+    outputs $program, "true\nfalse\n", "string equality";
 }
 
 {
@@ -152,7 +152,7 @@ use _007::Test;
         say(s1 != s2);
         .
 
-    outputs $program, "False\nTrue\n", "string inequality";
+    outputs $program, "false\ntrue\n", "string inequality";
 }
 
 {
@@ -163,7 +163,7 @@ use _007::Test;
         say(s1 < s2);
         .
 
-    outputs $program, "False\nTrue\n", "string less-than";
+    outputs $program, "false\ntrue\n", "string less-than";
 }
 
 {
@@ -174,7 +174,7 @@ use _007::Test;
         say(s1 > s2);
         .
 
-    outputs $program, "False\nTrue\n", "string greater-than";
+    outputs $program, "false\ntrue\n", "string greater-than";
 }
 
 {
@@ -185,7 +185,7 @@ use _007::Test;
         say(a1 == a2);
         .
 
-    outputs $program, "True\nFalse\n", "array equality";
+    outputs $program, "true\nfalse\n", "array equality";
 }
         
 {
@@ -196,7 +196,7 @@ use _007::Test;
         say(a1 != a2);
         .
 
-    outputs $program, "False\nTrue\n", "array inequality";
+    outputs $program, "false\ntrue\n", "array inequality";
 }
 
 {
@@ -206,7 +206,7 @@ use _007::Test;
         say(a3 == a3);
         .
 
-    outputs $program, "True\n", "nested array equality";
+    outputs $program, "true\n", "nested array equality";
 }
 
 {
@@ -217,7 +217,7 @@ use _007::Test;
         say(o1 == o2);
         .
 
-    outputs $program, "True\nFalse\n", "object equality";
+    outputs $program, "true\nfalse\n", "object equality";
 }
 
 {
@@ -228,7 +228,7 @@ use _007::Test;
         say(o1 != o2);
         .
 
-    outputs $program, "False\nTrue\n", "object inequality";
+    outputs $program, "false\ntrue\n", "object inequality";
 }
 
 {
@@ -238,7 +238,7 @@ use _007::Test;
         say(o3 == o3);
         .
 
-    outputs $program, "True\n", "nested object equality";
+    outputs $program, "true\n", "nested object equality";
 }
 
 {
@@ -247,7 +247,7 @@ use _007::Test;
         say(Int == Str);
         .
 
-    outputs $program, "True\nFalse\n", "type equality";
+    outputs $program, "true\nfalse\n", "type equality";
 }
 
 {
@@ -256,7 +256,7 @@ use _007::Test;
         say(Int != Str);
         .
 
-    outputs $program, "False\nTrue\n", "type inequality";
+    outputs $program, "false\ntrue\n", "type inequality";
 }
 
 {
@@ -271,7 +271,7 @@ use _007::Test;
         say(o1 == i1);
         .
 
-    outputs $program, "False\n" x 4, "equality testing across types (always False)";
+    outputs $program, "false\n" x 4, "equality testing across types (always false)";
 }
 
 {
@@ -286,52 +286,52 @@ use _007::Test;
         say(o1 != i1);
         .
 
-    outputs $program, "True\n" x 4, "inequality testing across types (always True)";
+    outputs $program, "true\n" x 4, "inequality testing across types (always true)";
 }
 
 {
-    outputs 'func foo() {}; say(foo == foo)', "True\n", "a func is equal to itself";
-    outputs 'macro foo() {}; say(foo == foo)', "True\n", "a macro is equal to itself";
-    outputs 'say(say == say)', "True\n", "a built-in func is equal to itself";
-    outputs 'say(infix:<+> == infix:<+>)', "True\n", "a built-in operator is equal to itself";
-    outputs 'say(new Q.Identifier { name: "foo" } == new Q.Identifier { name: "foo" })', "True\n",
+    outputs 'func foo() {}; say(foo == foo)', "true\n", "a func is equal to itself";
+    outputs 'macro foo() {}; say(foo == foo)', "true\n", "a macro is equal to itself";
+    outputs 'say(say == say)', "true\n", "a built-in func is equal to itself";
+    outputs 'say(infix:<+> == infix:<+>)', "true\n", "a built-in operator is equal to itself";
+    outputs 'say(new Q.Identifier { name: "foo" } == new Q.Identifier { name: "foo" })', "true\n",
         "two Qtrees with equal content are equal";
     outputs 'my a = []; for [1, 2] { func fn() {}; a = [fn, a] }; say(a[1][0] == a[0])',
-        "False\n", "the same func from two different frames are different";
-    outputs 'func foo() {}; my x = foo; { func foo() {}; say(x == foo) }', "False\n",
+        "false\n", "the same func from two different frames are different";
+    outputs 'func foo() {}; my x = foo; { func foo() {}; say(x == foo) }', "false\n",
         "distinct funcs are unequal, even with the same name and bodies (I)";
     outputs 'func foo() { say("OH HAI") }; my x = foo; { func foo() { say("OH HAI") }; say(x == foo) }',
-        "False\n", "distinct funcs are unequal, even with the same name and bodies (II)";
+        "false\n", "distinct funcs are unequal, even with the same name and bodies (II)";
 
-    outputs 'func foo() {}; func bar() {}; say(foo == bar)', "False\n",
+    outputs 'func foo() {}; func bar() {}; say(foo == bar)', "false\n",
         "distinct funcs are unequal";
-    outputs 'macro foo() {}; macro bar() {}; say(foo == bar)', "False\n",
+    outputs 'macro foo() {}; macro bar() {}; say(foo == bar)', "false\n",
         "distinct macros are unequal";
-    outputs 'say(say == type)', "False\n", "distinct built-in funcs are unequal";
-    outputs 'say(infix:<+> == prefix:<->)', "False\n",
+    outputs 'say(say == type)', "false\n", "distinct built-in funcs are unequal";
+    outputs 'say(infix:<+> == prefix:<->)', "false\n",
         "distinct built-in operators are unequal";
-    outputs 'func foo(y) {}; my x = foo; { func foo(x) {}; say(x == foo) }', "False\n",
+    outputs 'func foo(y) {}; my x = foo; { func foo(x) {}; say(x == foo) }', "false\n",
         "funcs with different parameters are unequal";
-    outputs 'func foo() {}; my x = foo; { func foo() { say("OH HAI") }; say(x == foo) }', "False\n",
+    outputs 'func foo() {}; my x = foo; { func foo() { say("OH HAI") }; say(x == foo) }', "false\n",
         "funcs with different bodies are unequal";
-    outputs 'say(new Q.Identifier { name: "foo" } == new Q.Identifier { name: "bar" })', "False\n",
+    outputs 'say(new Q.Identifier { name: "foo" } == new Q.Identifier { name: "bar" })', "false\n",
         "two Qtrees with distinct content are unequal";
 }
 
 {
-    outputs 'say(1 < 2); say(2 > 1); say(1 <= 2); say(2 <= 0)', "True\nTrue\nTrue\nFalse\n",
+    outputs 'say(1 < 2); say(2 > 1); say(1 <= 2); say(2 <= 0)', "true\ntrue\ntrue\nfalse\n",
         "relational operators work on integers";
-    outputs 'say("a" < "b"); say("b" > "a"); say("a" <= "c"); say("a" <= "B")', "True\nTrue\nTrue\nFalse\n",
+    outputs 'say("a" < "b"); say("b" > "a"); say("a" <= "c"); say("a" <= "B")', "true\ntrue\ntrue\nfalse\n",
         "relational operators work on strings";
 }
 
 {
-    outputs 'say(!False); say(!True); say(True || False); say(False || True); say(False && True)',
-        "True\nFalse\nTrue\nTrue\nFalse\n",
+    outputs 'say(!false); say(!true); say(true || false); say(false || true); say(false && true)',
+        "true\nfalse\ntrue\ntrue\nfalse\n",
         "boolean operators give the values expected";
-    outputs 'say(False && say("foo")); say(True || say("bar"))', "False\nTrue\n",
+    outputs 'say(false && say("foo")); say(true || say("bar"))', "false\ntrue\n",
         "boolean operators short-circuit";
-    outputs 'say(1 && 2); say("" && 3); say(False || None); say([0, 0, 7] || False)', "2\n\nNone\n[0, 0, 7]\n",
+    outputs 'say(1 && 2); say("" && 3); say(false || None); say([0, 0, 7] || false)', "2\n\nNone\n[0, 0, 7]\n",
         "boolean operators return one of their operands";
 }
 
@@ -343,7 +343,7 @@ use _007::Test;
         say(None == []);
         .
 
-    outputs $program, "True\nFalse\nFalse\nFalse\n", "equality testing with None matches only itself";
+    outputs $program, "true\nfalse\nfalse\nfalse\n", "equality testing with None matches only itself";
 }
 
 {
@@ -416,7 +416,7 @@ use _007::Test;
         say(!o.foo);
         .
 
-    outputs $program, "-2\n-7\n-12\nFalse\nFalse\nFalse\n", "all postfixes are tighter than both prefixes";
+    outputs $program, "-2\n-7\n-12\nfalse\nfalse\nfalse\n", "all postfixes are tighter than both prefixes";
 }
 
 {
@@ -448,16 +448,16 @@ use _007::Test;
         say(2 == 2 && 3 == 3);
         .
 
-    outputs $program, "Bond\nTrue\n", "&& binds looser than ==";
+    outputs $program, "Bond\ntrue\n", "&& binds looser than ==";
 }
 
 {
     my $program = q:to/./;
         say(0 && 1 || "James");
-        say(True || 0 && 0);
+        say(true || 0 && 0);
         .
 
-    outputs $program, "James\nTrue\n", "&& binds tighter than ||";
+    outputs $program, "James\ntrue\n", "&& binds tighter than ||";
 }
 
 {
@@ -474,7 +474,7 @@ use _007::Test;
         say(x);
         .
 
-    outputs $program, "False\nfoo\nbar\n", "assignment binds looser than all the other operators";
+    outputs $program, "false\nfoo\nbar\n", "assignment binds looser than all the other operators";
 }
 
 {
@@ -516,7 +516,7 @@ use _007::Test;
         my q = quasi<Q.Infix> { + }; say(q ~~ Q.Infix)
         .
 
-    outputs $program, "True\n", "successful typecheck";
+    outputs $program, "true\n", "successful typecheck";
 }
 
 {
@@ -524,7 +524,7 @@ use _007::Test;
         my q = quasi<Q.Infix> { + }; say(q ~~ Q.Prefix)
         .
 
-    outputs $program, "False\n", "unsuccessful typecheck";
+    outputs $program, "false\n", "unsuccessful typecheck";
 }
 
 {
@@ -532,7 +532,7 @@ use _007::Test;
         my q = 42; say(q ~~ Int)
         .
 
-    outputs $program, "True\n", "typecheck works for Val::Int";
+    outputs $program, "true\n", "typecheck works for Val::Int";
 }
 
 {
@@ -540,7 +540,7 @@ use _007::Test;
         my q = [4, 2]; say(q ~~ Array)
         .
 
-    outputs $program, "True\n", "typecheck works for Val::Array";
+    outputs $program, "true\n", "typecheck works for Val::Array";
 }
 
 {
@@ -548,7 +548,7 @@ use _007::Test;
         my q = {}; say(q ~~ Object)
         .
 
-    outputs $program, "True\n", "typecheck works for Val::Object";
+    outputs $program, "true\n", "typecheck works for Val::Object";
 }
 
 {
@@ -563,7 +563,7 @@ use _007::Test;
         say({} !~~ Int);
         .
 
-    outputs $program, "False\nTrue\nFalse\nFalse\nFalse\nTrue\nTrue\nTrue\n", "bunch of negative typechecks";
+    outputs $program, "false\ntrue\nfalse\nfalse\nfalse\ntrue\ntrue\ntrue\n", "bunch of negative typechecks";
 }
 
 {
@@ -645,7 +645,7 @@ use _007::Test;
 
     outputs
         $program,
-        "True\n",
+        "true\n",
         "+Val::Int outputs a Val::Int (regression)";
 }
 
@@ -656,7 +656,7 @@ use _007::Test;
 
     outputs
         $program,
-        "True\n",
+        "true\n",
         "+Val::Str outputs a Val::Int (regression)";
 }
 

--- a/t/builtins/operators.t
+++ b/t/builtins/operators.t
@@ -331,19 +331,19 @@ use _007::Test;
         "boolean operators give the values expected";
     outputs 'say(false && say("foo")); say(true || say("bar"))', "false\ntrue\n",
         "boolean operators short-circuit";
-    outputs 'say(1 && 2); say("" && 3); say(false || None); say([0, 0, 7] || false)', "2\n\nNone\n[0, 0, 7]\n",
+    outputs 'say(1 && 2); say("" && 3); say(false || none); say([0, 0, 7] || false)', "2\n\nnone\n[0, 0, 7]\n",
         "boolean operators return one of their operands";
 }
 
 {
     my $program = q:to/./;
-        say(None == None);
-        say(None == 0);
-        say(None == "");
-        say(None == []);
+        say(none == none);
+        say(none == 0);
+        say(none == "");
+        say(none == []);
         .
 
-    outputs $program, "true\nfalse\nfalse\nfalse\n", "equality testing with None matches only itself";
+    outputs $program, "true\nfalse\nfalse\nfalse\n", "equality testing with none matches only itself";
 }
 
 {
@@ -576,10 +576,10 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(None // "oh, James");
+        say(none // "oh, James");
         .
 
-    outputs $program, "oh, James\n", "defined-or with None as the lhs";
+    outputs $program, "oh, James\n", "defined-or with none as the lhs";
 }
 
 {

--- a/t/code-style/do-not-create-val-none.t
+++ b/t/code-style/do-not-create-val-none.t
@@ -7,11 +7,11 @@ my $files = find(".", /[".pm6" | ".t"] $/)\
     .join(" ");
 
 my @lines-with-val-none-new =
-    qqx[grep -Fwrin 'Val::NoneType.new' $files].lines\
-        # exception: we store Val::NoneType.new once as a constant
+    qqx[grep -Fwrin 'Val::None.new' $files].lines\
+        # exception: we store Val::None.new once as a constant
         .grep({ $_ !~~ /  ":constant NONE is export = " / });
 
 is @lines-with-val-none-new.join("\n"), "",
-    "no unnecessary calls to Val::NoneType.new";
+    "no unnecessary calls to Val::None.new";
 
 done-testing;

--- a/t/examples/in.t
+++ b/t/examples/in.t
@@ -5,8 +5,8 @@ my @lines = run-and-collect-lines("examples/in.007");
 
 is +@lines, 12, "correct number of lines of output";
 for [1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12] -> [$L1, $L2] {
-    is @lines[$L1 - 1], "True", "line #{$L1} correct";
-    is @lines[$L2 - 1], "False", "line #{$L2} correct";
+    is @lines[$L1 - 1], "true", "line #{$L1} correct";
+    is @lines[$L2 - 1], "false", "line #{$L2} correct";
 }
 
 done-testing;

--- a/t/features/begin.t
+++ b/t/features/begin.t
@@ -29,7 +29,7 @@ use _007::Test;
 
     outputs
         $program,
-        "None\n7\n",
+        "none\n7\n",
         "variables are declared already at parse time (but not assigned)";
 }
 
@@ -49,7 +49,7 @@ use _007::Test;
 
     outputs
         $program,
-        "None\n",
+        "none\n",
         "BEGIN blocks are scoped just like everything else";
 }
 

--- a/t/features/class.t
+++ b/t/features/class.t
@@ -53,7 +53,7 @@ ensure-feature-flag("CLASS");
         }
         .
 
-    outputs $program, "True\nFalse\n", "the `\{\}` syntax uses the built-in Object, even when overridden";
+    outputs $program, "true\nfalse\n", "the `\{\}` syntax uses the built-in Object, even when overridden";
 }
 
 {
@@ -73,7 +73,7 @@ ensure-feature-flag("CLASS");
         say(moo() ~~ C);
         .
 
-    outputs $program, "False\n", "lookup stays hygienic even when a `new C \{\}` is expanded";
+    outputs $program, "false\n", "lookup stays hygienic even when a `new C \{\}` is expanded";
 }
 
 {
@@ -87,7 +87,7 @@ ensure-feature-flag("CLASS");
         say(new D {} ~~ C);
         .
 
-    outputs $program, "False\n", "two different classes are not type compatible";
+    outputs $program, "false\n", "two different classes are not type compatible";
 }
 
 done-testing;

--- a/t/features/custom-ops.t
+++ b/t/features/custom-ops.t
@@ -472,7 +472,7 @@ use _007::Test;
             return "Mr. Bond";
         }
 
-        say(-13 ! None);
+        say(-13 ! none);
         .
 
     outputs $program, "Mr. Bond\n", "can declare an operator with infix:«...»";
@@ -636,7 +636,7 @@ use _007::Test;
         func fn(l, r) {
             c = c - 1;
             if !c {
-                return None;
+                return none;
             }
             return fn;
         }

--- a/t/features/expr.t
+++ b/t/features/expr.t
@@ -23,7 +23,7 @@ use _007::Test;
         .
 
     outputs $program,
-        qq[1\n3\n6\n2\n2\n5\n5\n-1\n1\nFalse\nFalse\n["a", "b", "c"]\nc\n6\n],
+        qq[1\n3\n6\n2\n2\n5\n5\n-1\n1\nfalse\nfalse\n["a", "b", "c"]\nc\n6\n],
         "various expressions work";
 }
 

--- a/t/features/funcs.t
+++ b/t/features/funcs.t
@@ -131,7 +131,7 @@ use _007::Test;
         .
 
     outputs $program,
-        "True\nFalse\n",
+        "true\nfalse\n",
         "can assign to a parameter which hides a subroutine (#68)";
 }
 

--- a/t/features/funcs.t
+++ b/t/features/funcs.t
@@ -81,7 +81,7 @@ use _007::Test;
         }
         .
 
-    outputs $program, "None\n", "using an outer lexical in a func that's called before the outer lexical's declaration";
+    outputs $program, "none\n", "using an outer lexical in a func that's called before the outer lexical's declaration";
 }
 
 {

--- a/t/features/if-statement.t
+++ b/t/features/if-statement.t
@@ -4,7 +4,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        if None { say("falsy none") }
+        if none { say("falsy none") }
         if 0 { say("falsy int") }
         if 7 { say("truthy int") }
         if "" { say("falsy str") }

--- a/t/features/macros.t
+++ b/t/features/macros.t
@@ -63,7 +63,7 @@ use _007::Test;
 {
     my $program = q:to/./;
         macro foo() {
-            return None;
+            return none;
         }
 
         foo();
@@ -73,7 +73,7 @@ use _007::Test;
     outputs
         $program,
         "OH HAI\n",
-        "a macro that returns `None` expands to nothing";
+        "a macro that returns `none` expands to nothing";
 }
 
 done-testing;

--- a/t/features/objects.t
+++ b/t/features/objects.t
@@ -94,7 +94,7 @@ use _007::Test;
 
     outputs
         $program,
-        qq[True\nFalse\n7\n\{bond: 8, james: "bond"\}\n\{x: 1, y: 2\}\nid\n],
+        qq[true\nfalse\n7\n\{bond: 8, james: "bond"\}\n\{x: 1, y: 2\}\nid\n],
         "built-in pseudo-inherited methods on objects";
 }
 
@@ -161,7 +161,7 @@ use _007::Test;
 
     outputs
         $program,
-        qq[True\nTrue\nTrue\n],
+        qq[true\ntrue\ntrue\n],
         "can create normal Val:: objects using typed object literals";
 }
 

--- a/t/features/q.t
+++ b/t/features/q.t
@@ -10,7 +10,7 @@ use _007::Test;
 
     outputs
         $program,
-        "None\n",
+        "none\n",
         "Q.Statement.Return can be constructed without an 'expr' property (#84)";
 }
 
@@ -32,7 +32,7 @@ use _007::Test;
 
     outputs
         $program,
-        "None\n",
+        "none\n",
         "Q.Statement.If can be constructed without an 'else' property (#84)";
 }
 

--- a/t/features/quasi.t
+++ b/t/features/quasi.t
@@ -26,7 +26,7 @@ use _007::Test;
         say(moo());
         .
 
-    outputs $program, "None\n", "Empty quasiquote results in a None value";
+    outputs $program, "none\n", "Empty quasiquote results in a none value";
 }
 
 {
@@ -142,7 +142,7 @@ use _007::Test;
 {
     my $program = q:to/./;
         say(type(quasi<Q.Literal> { 7 }));
-        say(type(quasi<Q.Literal> { None }));
+        say(type(quasi<Q.Literal> { none }));
         say(type(quasi<Q.Literal> { "James Bond" }));
         .
 
@@ -161,7 +161,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(type(quasi<Q.Literal.None> { None }));
+        say(type(quasi<Q.Literal.None> { none }));
         .
 
     outputs $program, "<type Q.Literal.None>\n", "quasi<Q.Literal.None>";
@@ -207,7 +207,7 @@ use _007::Test;
 {
     my $program = q:to/./;
         say(type(quasi<Q.Term> { 7 }));
-        say(type(quasi<Q.Term> { None }));
+        say(type(quasi<Q.Term> { none }));
         say(type(quasi<Q.Term> { "James Bond" }));
         say(type(quasi<Q.Term> { [0, 0, 7] }));
         say(type(quasi<Q.Term> { new Object { james: "Bond" } }));

--- a/t/features/regex.t
+++ b/t/features/regex.t
@@ -26,7 +26,7 @@ ensure-feature-flag("REGEX");
         say(!!/"hey"/);
         .
 
-    outputs $program, "True\n", "Regexes are truthy";
+    outputs $program, "true\n", "Regexes are truthy";
 }
 {
     my @programs =
@@ -60,7 +60,7 @@ ensure-feature-flag("REGEX");
 
     for @programs -> $program {
         my $code = $program.key;
-        my $expected = $program.value;
+        my $expected = $program.value.lc;
         outputs $code, "$expected\n", "Testing regex, program: $code";
     }
 }

--- a/t/features/return.t
+++ b/t/features/return.t
@@ -60,7 +60,7 @@ use _007::Test;
         say(f());
         .
 
-    outputs $program, "None\n", "sub returning nothing";
+    outputs $program, "none\n", "sub returning nothing";
 }
 
 {

--- a/t/features/variables.t
+++ b/t/features/variables.t
@@ -8,7 +8,7 @@ use _007::Test;
         say(u);
         .
 
-    outputs $program, "None\n", "variables can be declared without being assigned";
+    outputs $program, "none\n", "variables can be declared without being assigned";
 }
 
 done-testing;


### PR DESCRIPTION
As discussed in #390.

I'm still not sure, but I _think_ I like this better on balance. Also pretty sure I'd like it better than `TRUE`, `FALSE`, and `NONE` everywhere in code.

A nice unexpected consequence is that we can now undo the `NoneType` renaming from #168; the enum _type_ can now safely be called `None` again.