### PR TITLE
Installing a new op removes the old op of that name

### DIFF
--- a/t/features/custom-ops.t
+++ b/t/features/custom-ops.t
@@ -699,4 +699,32 @@ use _007::Test;
     parse-error $program, X::Redeclaration, "can't declare an infix and a postfix with the same name";
 }
 
+{
+    my $program = q:to/./;
+        {
+            func postfix:<!>(t) is assoc("right") {
+                "postfix:<!>(" ~ t ~ ")";
+            }
+            func prefix:<?>(t) is equiv(postfix:<!>) {
+                "prefix:<?>(" ~ t ~ ")";
+            }
+            say(?"term"!);
+        }
+        {
+            func prefix:<?>(t) is assoc("right") {
+                "prefix:<?>(" ~ t ~ ")";
+            }
+            func postfix:<!>(t) is equiv(prefix:<?>) {
+                "postfix:<!>(" ~ t ~ ")";
+            }
+            say(?"term"!);
+        }
+        .
+
+    outputs
+        $program,
+        "prefix:<?>(postfix:<!>(term))\nprefix:<?>(postfix:<!>(term))\n",
+        "with same-precedence right-associative prefix/postfix ops, the postfix evaluates first (no matter the order declared) (#372)";
+}
+
 done-testing;


### PR DESCRIPTION
A new invariant on the OpScope object is that an operator (say
`infix:+`) is only allowed to occur *once* in the lookup tables.
When a new operator is added, any operator with the same name is
removed.

An odd consequence of this is that we can end up with precedence
levels containing no operator. Although that's an odd thing, I
don't see any negative effects. In particular, since precedence
levels are not first-class and only accessible via the ops they
contain, an empty precedence level will simply be inaccessible.

To be honest, this fix should have been how it was done from the
start. We clone the OpScope object anyway, so it makes sense to
destroy old ops from the copy.

Closes #372.

On that note, the referenced issue concluded that "definition sites"
was the way to fix this; turns out the fix in this PR is _much_ more
straightforward. Definition sites would probably have worked too,
but... now we don't have to. 😄 