### PR TITLE
Make built-ins unassignable

### DIFF
--- a/lib/_007/Parser/Actions.pm6
+++ b/lib/_007/Parser/Actions.pm6
@@ -324,8 +324,12 @@ class _007::Parser::Actions {
                 if $infix ~~ Q::Infix::Assignment && $t1 ~~ Q::Identifier {
                     my $frame = $*runtime.current-frame;
                     my $symbol = $t1.name.value;
-                    die X::Undeclared.new(:$symbol)
-                        unless @*declstack[*-1]{$symbol} :exists;
+                    if @*declstack[*-1]{$symbol} :!exists {
+                        if $*runtime.maybe-get-var($symbol) {
+                            die X::Assignment::ReadOnly.new(:declname("builtin"), :$symbol);
+                        }
+                        die X::Undeclared.new(:$symbol)
+                    }
                     my $decltype = @*declstack[*-1]{$symbol};
                     my $declname = $decltype.^name.subst(/ .* '::'/, "").lc;
                     die X::Assignment::ReadOnly.new(:$declname, :$symbol)

--- a/t/builtins/unassignable.t
+++ b/t/builtins/unassignable.t
@@ -1,0 +1,18 @@
+use _007::Builtins;
+use Test;
+use _007::Test;
+
+for builtins-pad().properties {
+    my $name = .value.?escaped-name || .key;
+    
+    my $program = qq:to/./;
+        {$name} = "trying to assign this built-in";
+        .
+
+    parse-error
+        $program,
+        X::Assignment::ReadOnly,
+        "can't assign to '{$name}' built-in";
+}
+
+done-testing;


### PR DESCRIPTION
Before this change, we already got an error when trying to assign
to a built-in function or type. But the error was "Variable not
declared", which is confusing. The name *is* declared, just not
inside of the program text itself. But the check that led to the
error didn't consider that.

What we do now with an assignment is, if we find a variable that
hasn't been declared within the program text, we tentatively make
a (static) lookup on that variable.

- If we find something, then it's a built-in, and we throw
  X::Assignment::ReadOnly. [This is the new bit.]

- If we don't find anything, then (like before), we throw
  X::Undefined.

Closes #411.