### PR TITLE
Make sure operators ending in alphanumerics also have a word boundary after them

### DIFF
--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -305,7 +305,7 @@ grammar _007::Parser::Syntax {
 
     method infix {
         my @ops = $*parser.opscope.ops<infix>.keys;
-        if /@ops/(self) -> $cur {
+        if /@ops [<!after \w> | <!before \w>]/(self) -> $cur {
             return $cur."!reduce"("infix");
         }
         return /<!>/(self);

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -332,7 +332,7 @@ grammar _007::Parser::Syntax {
         }
 
         my @ops = $*parser.opscope.ops<postfix>.keys;
-        if /@ops/(self) -> $cur {
+        if /@ops [<!after \w> | <!before \w>]/(self) -> $cur {
             return $cur."!reduce"("postfix");
         }
         return /<!>/(self);

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -155,7 +155,7 @@ grammar _007::Parser::Syntax {
 
     method prefix {
         my @ops = $*parser.opscope.ops<prefix>.keys;
-        if /@ops/(self) -> $cur {
+        if /@ops [<!after \w> | <!before \w>]/(self) -> $cur {
             return $cur."!reduce"("prefix");
         }
         return /<!>/(self);

--- a/t/features/custom-ops.t
+++ b/t/features/custom-ops.t
@@ -727,4 +727,26 @@ use _007::Test;
         "with same-precedence right-associative prefix/postfix ops, the postfix evaluates first (no matter the order declared) (#372)";
 }
 
+{
+    my $program = q:to/./;
+        func prefix:<H>(n) {
+            "oops"
+        }
+        say(H50);
+    .
+
+    parse-error $program, X::Undeclared, "prefixes that end in an alphanumeric must also end in a word boundary (#408) (I)";
+}
+
+{
+    my $program = q:to/./;
+        func prefix:<H5>(n) {
+            "oops"
+        }
+        say(H50);
+    .
+
+    parse-error $program, X::Undeclared, "prefixes that end in an alphanumeric must also end in a word boundary (#408) (II)";
+}
+
 done-testing;

--- a/t/features/custom-ops.t
+++ b/t/features/custom-ops.t
@@ -771,4 +771,13 @@ use _007::Test;
     parse-error $program, X::AdHoc, "infixes that end in an alphanumeric must also end in a word boundary (II)";
 }
 
+{
+    my $program = q:to/./;
+        func postfix:<P>(n) { "oops" }
+        say(2 PP)
+    .
+
+    parse-error $program, X::AdHoc, "postfixes that end in an alphanumeric must also end in a word boundary";
+}
+
 done-testing;

--- a/t/features/custom-ops.t
+++ b/t/features/custom-ops.t
@@ -749,4 +749,26 @@ use _007::Test;
     parse-error $program, X::Undeclared, "prefixes that end in an alphanumeric must also end in a word boundary (#408) (II)";
 }
 
+{
+    my $program = q:to/./;
+        func infix:<H>(x, y) {
+            "oops"
+        }
+        say(2 H40);
+    .
+
+    parse-error $program, X::AdHoc, "infixes that end in an alphanumeric must also end in a word boundary (I)";
+}
+
+{
+    my $program = q:to/./;
+        func infix:<H4>(x, y) {
+            "oops"
+        }
+        say(2 H40);
+    .
+
+    parse-error $program, X::AdHoc, "infixes that end in an alphanumeric must also end in a word boundary (II)";
+}
+
 done-testing;


### PR DESCRIPTION
Ended up doing not just prefixes (as #408 discusses), but also infixes and postfixes, which suffer from the same problem.