### PR TITLE
Document how to install 007 with zef

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,7 @@
       }
     </style>
   </head>
-  <body class="checksum-a04500">
+  <body class="checksum-fbb5ae">
 <a href="https://github.com/masak/007"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 <div class="container">
 <p>This documentation has four parts:</p>
@@ -65,13 +65,16 @@
 <p><em>This document is still being written. Paragraphs marked 🔮 represent future features of 007 that are planned but not yet implemented.</em></p>
 <h1 id="language-guide">Language guide</h1>
 <h2 id="getting-started">Getting started</h2>
-<h3 id="installation">Installation</h3>
+<h3 id="installation-with-zef">Installation (with zef)</h3>
+<p>If you're just planning to be a 007 end user, <code>zef</code> is the recommended way to install 007:</p>
+<div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash"><span class="ex">zef</span> install 007</code></pre></div>
+<p>In order to get the <code>zef</code> installer, you first need <a href="https://perl6.org/downloads/">Rakudo Perl 6</a>. Instructions for how to install <code>zef</code> itself can be found in the <a href="https://github.com/ugexe/zef#installation"><code>zef</code> README</a>.</p>
+<h3 id="installation-from-source">Installation (from source)</h3>
 <p>Make sure you have <a href="https://perl6.org/downloads/">Rakudo Perl 6</a> installed and in your path.</p>
 <p>Then, clone the 007 repository. (This step requires Git. There's also <a href="https://github.com/masak/007/archive/master.zip">a zip file</a>.)</p>
 <div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash">$ <span class="fu">git</span> clone https://github.com/masak/007.git
 [<span class="ex">...</span>]</code></pre></div>
-<h3 id="setting-an-environment-variable">Setting an environment variable</h3>
-<p>We're one step away from running our first 007 program. Before that, we need to set an environment variable <code>PERL6LIB</code>:</p>
+<p>Finally, we need to set an environment variable <code>PERL6LIB</code>:</p>
 <div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash">$ <span class="bu">cd</span> 007
 $ <span class="bu">export</span> <span class="va">PERL6LIB=$(</span><span class="bu">pwd</span><span class="va">)</span>/lib</code></pre></div>
 <blockquote class="info">

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,7 @@
       }
     </style>
   </head>
-  <body class="checksum-fbb5ae">
+  <body class="checksum-1394e9">
 <a href="https://github.com/masak/007"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 <div class="container">
 <p>This documentation has four parts:</p>
@@ -69,6 +69,10 @@
 <p>If you're just planning to be a 007 end user, <code>zef</code> is the recommended way to install 007:</p>
 <div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash"><span class="ex">zef</span> install 007</code></pre></div>
 <p>In order to get the <code>zef</code> installer, you first need <a href="https://perl6.org/downloads/">Rakudo Perl 6</a>. Instructions for how to install <code>zef</code> itself can be found in the <a href="https://github.com/ugexe/zef#installation"><code>zef</code> README</a>.</p>
+<blockquote class="info">
+<h4 id="using-zef">💡 Using <code>zef</code></h4>
+<p>At any later point, you can use <code>zef upgrade</code> to get an up-to-date 007, or <code>zef uninstall</code> to remove 007 from your system.</p>
+</blockquote>
 <h3 id="installation-from-source">Installation (from source)</h3>
 <p>Make sure you have <a href="https://perl6.org/downloads/">Rakudo Perl 6</a> installed and in your path.</p>
 <p>Then, clone the 007 repository. (This step requires Git. There's also <a href="https://github.com/masak/007/archive/master.zip">a zip file</a>.)</p>

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -19,7 +19,20 @@ features of 007 that are planned but not yet implemented.*
 
 ## Getting started
 
-### Installation
+### Installation (with zef)
+
+If you're just planning to be a 007 end user, `zef` is the recommended way to
+install 007:
+
+```sh
+zef install 007
+```
+
+In order to get the `zef` installer, you first need [Rakudo Perl
+6](https://perl6.org/downloads/). Instructions for how to install `zef` itself
+can be found in the [`zef` README](https://github.com/ugexe/zef#installation).
+
+### Installation (from source)
 
 Make sure you have [Rakudo Perl 6](https://perl6.org/downloads/) installed and
 in your path.
@@ -32,10 +45,7 @@ $ git clone https://github.com/masak/007.git
 [...]
 ```
 
-### Setting an environment variable
-
-We're one step away from running our first 007 program. Before that, we need to
-set an environment variable `PERL6LIB`:
+Finally, we need to set an environment variable `PERL6LIB`:
 
 ```sh
 $ cd 007

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -32,6 +32,11 @@ In order to get the `zef` installer, you first need [Rakudo Perl
 6](https://perl6.org/downloads/). Instructions for how to install `zef` itself
 can be found in the [`zef` README](https://github.com/ugexe/zef#installation).
 
+> #### 💡 Using `zef`
+>
+> At any later point, you can use `zef upgrade` to get an up-to-date 007, or
+> `zef uninstall` to remove 007 from your system.
+
 ### Installation (from source)
 
 Make sure you have [Rakudo Perl 6](https://perl6.org/downloads/) installed and


### PR DESCRIPTION
As usual, please ignore the generated output in `docs/index.html` and focus on the source in `documentation/README.md`. Kthx.

Closes #446.