### PR TITLE
Put zero-width word boundaries after all of the keywords in the grammar

### DIFF
--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -92,7 +92,7 @@ grammar _007::Parser::Syntax {
     }
 
     token statement:for {
-        for <.ws> <xblock>
+        for» <.ws> <xblock>
     }
     token statement:while {
         while <.ws> <xblock>

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -98,7 +98,7 @@ grammar _007::Parser::Syntax {
         while» <.ws> <xblock>
     }
     token statement:BEGIN {
-        BEGIN <.ws> <block>
+        BEGIN» <.ws> <block>
     }
     token statement:class {
         class <.ws>

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -74,7 +74,7 @@ grammar _007::Parser::Syntax {
         <.finishpad>
     }
     token statement:return {
-        return [<.ws> <EXPR>]?
+        return» [<.ws> <EXPR>]?
     }
 
     token statement:throw {

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -258,7 +258,7 @@ grammar _007::Parser::Syntax {
         <identifier>
     }
     token term:func {
-        func <.ws> <identifier>?
+        func» <.ws> <identifier>?
         :my $*in_routine = True;
         <.newpad>
         {

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -112,7 +112,7 @@ grammar _007::Parser::Syntax {
         <trait> *
     }
     token trait {
-        'is' <.ws> <identifier> '(' <EXPR> ')'
+        is» <.ws> <identifier> '(' <EXPR> ')'
     }
 
     # requires a <.newpad> before invocation

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -78,7 +78,7 @@ grammar _007::Parser::Syntax {
     }
 
     token statement:throw {
-        throw [<.ws> <EXPR>]?
+        throw» [<.ws> <EXPR>]?
     }
 
     token statement:if {

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -82,7 +82,7 @@ grammar _007::Parser::Syntax {
     }
 
     token statement:if {
-        if <.ws> <xblock>
+        if» <.ws> <xblock>
         [  <.ws> else <.ws>
             [
                 | <else=.pblock>

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -101,7 +101,7 @@ grammar _007::Parser::Syntax {
         BEGIN» <.ws> <block>
     }
     token statement:class {
-        class <.ws>
+        class» <.ws>
         { check-feature-flag("'class' keyword", "CLASS"); }
         <identifier> <.ws>
         { declare(Q::Statement::Class, $<identifier>.ast.name.value); }

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -95,7 +95,7 @@ grammar _007::Parser::Syntax {
         for» <.ws> <xblock>
     }
     token statement:while {
-        while <.ws> <xblock>
+        while» <.ws> <xblock>
     }
     token statement:BEGIN {
         BEGIN <.ws> <block>

--- a/t/features/class.t
+++ b/t/features/class.t
@@ -90,4 +90,16 @@ ensure-feature-flag("CLASS");
     outputs $program, "false\n", "two different classes are not type compatible";
 }
 
+{
+    my $program = q:to/./;
+        func class_7() {
+            say("OH HAI");
+        }
+
+        class_7();
+        .
+
+    outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'class'";
+}
+
 done-testing;

--- a/t/integration/corner-cases.t
+++ b/t/integration/corner-cases.t
@@ -381,4 +381,13 @@ use _007::Test;
     outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'BEGIN'";
 }
 
+{
+    my $program = q:to/./;
+        func infix:<~?>(left, right) islooser(infix:<+>) {
+        }
+        .
+
+    parse-error $program, X::Syntax::Missing, "must have a space after 'is' in a trait";
+}
+
 done-testing;

--- a/t/integration/corner-cases.t
+++ b/t/integration/corner-cases.t
@@ -309,4 +309,16 @@ use _007::Test;
     outputs $program, "OH HAI\n", "can put many semicolons after a statement";
 }
 
+{
+    my $program = q:to/./;
+        func if_1() {
+            say("OH HAI");
+        }
+
+        if_1();
+        .
+
+    outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'if'";
+}
+
 done-testing;

--- a/t/integration/corner-cases.t
+++ b/t/integration/corner-cases.t
@@ -321,4 +321,16 @@ use _007::Test;
     outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'if'";
 }
 
+{
+    my $program = q:to/./;
+        func return_2() {
+            say("OH HAI");
+        }
+
+        return_2();
+        .
+
+    outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'return'";
+}
+
 done-testing;

--- a/t/integration/corner-cases.t
+++ b/t/integration/corner-cases.t
@@ -357,4 +357,16 @@ use _007::Test;
     outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'for'";
 }
 
+{
+    my $program = q:to/./;
+        func while_5() {
+            say("OH HAI");
+        }
+
+        while_5();
+        .
+
+    outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'while'";
+}
+
 done-testing;

--- a/t/integration/corner-cases.t
+++ b/t/integration/corner-cases.t
@@ -345,4 +345,16 @@ use _007::Test;
     outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'throw'";
 }
 
+{
+    my $program = q:to/./;
+        func for_4() {
+            say("OH HAI");
+        }
+
+        for_4();
+        .
+
+    outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'for'";
+}
+
 done-testing;

--- a/t/integration/corner-cases.t
+++ b/t/integration/corner-cases.t
@@ -369,4 +369,16 @@ use _007::Test;
     outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'while'";
 }
 
+{
+    my $program = q:to/./;
+        func BEGIN_6() {
+            say("OH HAI");
+        }
+
+        BEGIN_6();
+        .
+
+    outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'BEGIN'";
+}
+
 done-testing;

--- a/t/integration/corner-cases.t
+++ b/t/integration/corner-cases.t
@@ -333,4 +333,16 @@ use _007::Test;
     outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'return'";
 }
 
+{
+    my $program = q:to/./;
+        func throw_3() {
+            say("OH HAI");
+        }
+
+        throw_3();
+        .
+
+    outputs $program, "OH HAI\n", "can start an expression with an identifier prefixed 'throw'";
+}
+
 done-testing;

--- a/t/integration/corner-cases.t
+++ b/t/integration/corner-cases.t
@@ -390,4 +390,15 @@ use _007::Test;
     parse-error $program, X::Syntax::Missing, "must have a space after 'is' in a trait";
 }
 
+{
+    my $program = q:to/./;
+        func func_7() {
+            say("OH HAI");
+        }
+        my f = func_7();
+        .
+
+    outputs $program, "OH HAI\n", "an identifier prefixed 'func' is not confused with a function expression";
+}
+
 done-testing;


### PR DESCRIPTION
The lack of which caused at least one parsing bug, fortunately in my own unpublished 007 code.

In short, it should be OK to have and use an identifier called `if_startswith` even though the language has a keyword `if` which is a prefix of that identifier.

Closes #397.