### PR TITLE
Introduce a 'Dict' type

### DIFF
--- a/examples/hanoi.007
+++ b/examples/hanoi.007
@@ -8,7 +8,7 @@ my DISK = {
 };
 
 my state = [
-    [DISK.huge, DISK.large, DISK.small, DISK.tiny],
+    [DISK["huge"], DISK["large"], DISK["small"], DISK["tiny"]],
     [],
     []
 ];

--- a/examples/in.007
+++ b/examples/in.007
@@ -7,7 +7,7 @@ func infix:<in>(value, container) {
         }
         return false;
     }
-    else if container ~~ Object {
+    else if container ~~ Dict {
         return container.has(value);
     }
     else if container ~~ Str {
@@ -15,7 +15,7 @@ func infix:<in>(value, container) {
     }
     else {
         throw new Exception {
-            message: "Wrong type to infix:<in>. Expected Array or Object or Str, was " ~ type(container),
+            message: "Wrong type to infix:<in>. Expected Array or Dict or Str, was " ~ type(container),
         };
     }
 }
@@ -29,7 +29,7 @@ func infix:<not in>(value, container) {
         }
         return true;
     }
-    else if container ~~ Object {
+    else if container ~~ Dict {
         return !container.has(value);
     }
     else if container ~~ Str {
@@ -37,7 +37,7 @@ func infix:<not in>(value, container) {
     }
     else {
         throw new Exception {
-            message: "Wrong type to infix:<not in>. Expected Array or Object or Str, was " ~ type(container),
+            message: "Wrong type to infix:<not in>. Expected Array or Dict or Str, was " ~ type(container),
         };
     }
 }

--- a/lib/_007/Builtins.pm6
+++ b/lib/_007/Builtins.pm6
@@ -358,7 +358,7 @@ my &parameter = { Q::Parameter.new(:identifier(Q::Identifier.new(:name(Val::Str.
     default { die "Unknown type {.value.^name}" }
 });
 
-my $builtins-pad = Val::Object.new;
+my $builtins-pad = Val::Dict.new;
 for @builtins -> Pair (:key($name), :$value) {
     $builtins-pad.properties{$name} = $value;
 }

--- a/lib/_007/Builtins.pm6
+++ b/lib/_007/Builtins.pm6
@@ -149,7 +149,7 @@ my @builtins =
         sub ($lhs, $rhs) {
             assert-type(:value($rhs), :type(Val::Type), :operation<~~>);
 
-            return wrap($lhs ~~ $rhs.type);
+            return wrap($rhs.type ~~ Val::Object || $lhs ~~ $rhs.type);
         },
         :qtype(Q::Infix),
         :precedence{ equiv => "infix:==" },
@@ -158,7 +158,7 @@ my @builtins =
         sub ($lhs, $rhs) {
             assert-type(:value($rhs), :type(Val::Type), :operation<!~~>);
 
-            return wrap($lhs !~~ $rhs.type);
+            return wrap($rhs.type !~~ Val::Object && $lhs !~~ $rhs.type);
         },
         :qtype(Q::Infix),
         :precedence{ equiv => "infix:==" },

--- a/lib/_007/Equal.pm6
+++ b/lib/_007/Equal.pm6
@@ -21,7 +21,7 @@ multi equal-value(Val::Array $l, Val::Array $r) {
     [&&] $l.elements == $r.elements,
         |(^$l.elements).map(&equal-at-index);
 }
-multi equal-value(Val::Object $l, Val::Object $r) {
+multi equal-value(Val::Dict $l, Val::Dict $r) {
     if %*equality-seen{$l.WHICH} && %*equality-seen{$r.WHICH} {
         return $l === $r;
     }

--- a/lib/_007/Parser/Actions.pm6
+++ b/lib/_007/Parser/Actions.pm6
@@ -683,11 +683,7 @@ class _007::Parser::Actions {
     }
 
     method term:dict ($/) {
-        my $type = Val::Type.of(Val::Dict);
-
-        make Q::Term::Dict.new(
-            :$type,
-            :propertylist($<propertylist>.ast));
+        make Q::Term::Dict.new(:propertylist($<propertylist>.ast));
     }
 
     method term:my ($/) {

--- a/lib/_007/Parser/Actions.pm6
+++ b/lib/_007/Parser/Actions.pm6
@@ -677,7 +677,7 @@ class _007::Parser::Actions {
             }
         }
 
-        make Q::Term::Dict.new(
+        make Q::Term::Object.new(
             :$type,
             :propertylist($<propertylist>.ast));
     }

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -19,7 +19,7 @@ grammar _007::Parser::Syntax {
     token newpad { <?> {
         $*parser.push-opscope;
         @*declstack.push(@*declstack ?? @*declstack[*-1].clone !! {});
-        $*runtime.enter($*runtime.current-frame, Val::Object.new, Q::StatementList.new);
+        $*runtime.enter($*runtime.current-frame, Val::Dict.new, Q::StatementList.new);
     } }
 
     token finishpad { <?> {
@@ -40,7 +40,7 @@ grammar _007::Parser::Syntax {
             if $*runtime.declared-locally($symbol);
         my $frame = $*runtime.current-frame();
         die X::Redeclaration::Outer.new(:$symbol)
-            if %*assigned{$frame.id ~ $symbol};
+            if %*assigned{$frame.WHICH ~ $symbol};
         my $identifier = Q::Identifier.new(
             :name(Val::Str.new(:value($symbol))),
             :$frame);
@@ -223,7 +223,7 @@ grammar _007::Parser::Syntax {
             || "<" <.ws> $<qtype>=["Q.PropertyList"] ">" <.ws> '{' <.ws> <propertylist> <.ws> '}'
             || "<" <.ws> $<qtype>=["Q.Term"] ">" <.ws> '{' <.ws> <term> <.ws> '}'
             || "<" <.ws> $<qtype>=["Q.Term.Array"] ">" <.ws> '{' <.ws> <term:array> <.ws> '}'
-            || "<" <.ws> $<qtype>=["Q.Term.Object"] ">" <.ws> '{' <.ws> <term:object> <.ws> '}'
+            || "<" <.ws> $<qtype>=["Q.Term.Dict"] ">" <.ws> '{' <.ws> <term:object> <.ws> '}'
             || "<" <.ws> $<qtype>=["Q.Term.Quasi"] ">" <.ws> '{' <.ws> <term:quasi> <.ws> '}'
             || "<" <.ws> $<qtype>=["Q.Trait"] ">" <.ws> '{' <.ws> <trait> <.ws> '}'
             || "<" <.ws> $<qtype>=["Q.TraitList"] ">" <.ws> '{' <.ws> <traitlist> <.ws> '}'
@@ -251,7 +251,7 @@ grammar _007::Parser::Syntax {
         }> <.ws>
         '{' ~ '}' <propertylist>
     }
-    token term:object {
+    token term:dict {
         '{' ~ '}' <propertylist>
     }
     token term:identifier {

--- a/lib/_007/Q.pm6
+++ b/lib/_007/Q.pm6
@@ -288,12 +288,11 @@ class Q::Term::Array does Q::Term {
     }
 }
 
-### ### Q::Term::Object
+### ### Q::Term::Dict
 ###
-### An object. Object terms consist of an optional *type*, and a property list
-### with zero or more key/value pairs.
+### A dict. Dict terms consist of an entry list with zero or more key/value pairs.
 ###
-class Q::Term::Object does Q::Term {
+class Q::Term::Dict does Q::Term {
     has Val::Type $.type;
     has $.propertylist;
 
@@ -391,7 +390,7 @@ class Q::Term::Func does Q::Term does Q::Declaration {
 class Q::Block does Q {
     has $.parameterlist;
     has $.statementlist;
-    has Val::Object $.static-lexpad is rw = Val::Object.new;
+    has Val::Dict $.static-lexpad is rw = Val::Dict.new;
     # XXX
     has $.frame is rw;
 
@@ -530,7 +529,7 @@ class Q::Postfix::Index is Q::Postfix {
                     if $index.value < 0;
                 return .elements[$index.value];
             }
-            when Val::Object | Val::Func | Q {
+            when Val::Dict | Val::Func | Q {
                 my $property = $.index.eval($runtime);
                 die X::Subscript::NonString.new
                     if $property !~~ Val::Str;
@@ -553,7 +552,7 @@ class Q::Postfix::Index is Q::Postfix {
                     if $index.value < 0;
                 .elements[$index.value] = $value;
             }
-            when Val::Object | Q {
+            when Val::Dict | Q {
                 my $property = $.index.eval($runtime);
                 die X::Subscript::NonString.new
                     if $property !~~ Val::Str;
@@ -602,7 +601,7 @@ class Q::Postfix::Property is Q::Postfix {
 
     method put-value($value, $runtime) {
         given $.operand.eval($runtime) {
-            when Val::Object | Q {
+            when Val::Dict | Q {
                 my $propname = $.property.name.value;
                 $runtime.put-property($_, $propname, $value);
             }
@@ -666,7 +665,7 @@ class Q::Term::Quasi does Q::Term {
                 if $thing ~~ Val::Array;
 
             return $thing.new(:properties(%($thing.properties.map({ .key => interpolate(.value) }))))
-                if $thing ~~ Val::Object;
+                if $thing ~~ Val::Dict;
 
             return $thing
                 if $thing ~~ Val;

--- a/lib/_007/Q.pm6
+++ b/lib/_007/Q.pm6
@@ -529,7 +529,16 @@ class Q::Postfix::Index is Q::Postfix {
                     if $index.value < 0;
                 return .elements[$index.value];
             }
-            when Val::Dict | Val::Func | Q {
+            when Val::Dict {
+                my $property = $.index.eval($runtime);
+                die X::Subscript::NonString.new
+                    if $property !~~ Val::Str;
+                my $propname = $property.value;
+                die X::Property::NotFound.new(:$propname, :type(Val::Dict))
+                    if .properties{$propname} :!exists;
+                return .properties{$propname};
+            }
+            when Val::Func | Q {
                 my $property = $.index.eval($runtime);
                 die X::Subscript::NonString.new
                     if $property !~~ Val::Str;

--- a/lib/_007/Q.pm6
+++ b/lib/_007/Q.pm6
@@ -288,6 +288,21 @@ class Q::Term::Array does Q::Term {
     }
 }
 
+### ### Q::Term::Object
+###
+### An object.
+###
+class Q::Term::Object does Q::Term {
+    has Val::Type $.type;
+    has $.propertylist;
+
+    method eval($runtime) {
+        return $.type.create(
+            $.propertylist.properties.elements.map({.key.value => .value.eval($runtime)})
+        );
+    }
+}
+
 ### ### Q::Term::Dict
 ###
 ### A dict. Dict terms consist of an entry list with zero or more key/value pairs.

--- a/lib/_007/Q.pm6
+++ b/lib/_007/Q.pm6
@@ -308,13 +308,12 @@ class Q::Term::Object does Q::Term {
 ### A dict. Dict terms consist of an entry list with zero or more key/value pairs.
 ###
 class Q::Term::Dict does Q::Term {
-    has Val::Type $.type;
     has $.propertylist;
 
     method eval($runtime) {
-        return $.type.create(
+        return Val::Dict.new(:properties(
             $.propertylist.properties.elements.map({.key.value => .value.eval($runtime)})
-        );
+        ));
     }
 }
 

--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -549,10 +549,6 @@ class _007::Runtime {
                 return $obj;
             });
         }
-        elsif $propname eq "id" {
-            # XXX: Make this work for Q-type objects, too.
-            return Val::Int.new(:value($obj.id));
-        }
         elsif $obj ~~ Val::Type && $obj.type === Q && $propname eq "ArgumentList" {
             return Val::Type.of(Q::ArgumentList);
         }

--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -512,22 +512,22 @@ class _007::Runtime {
         elsif $obj ~~ Val::Func && $propname eq any <outer-frame static-lexpad parameterlist statementlist> {
             return $obj."$propname"();
         }
-        elsif $obj ~~ (Q | Val::Dict) && ($obj.properties{$propname} :exists) {
+        elsif $obj ~~ Q && ($obj.properties{$propname} :exists) {
             return $obj.properties{$propname};
         }
-        elsif $propname eq "get" {
+        elsif $obj ~~ Val::Dict && $propname eq "get" {
             return builtin(sub get($prop) {
-                return self.property($obj, $prop.value);
+                return $obj.properties{$prop.value};
             });
         }
-        elsif $propname eq "keys" {
+        elsif $obj ~~ Val::Dict && $propname eq "keys" {
             return builtin(sub keys() {
                 return Val::Array.new(:elements($obj.properties.keys.map({
                     Val::Str.new(:$^value)
                 })));
             });
         }
-        elsif $propname eq "has" {
+        elsif $obj ~~ Val::Dict && $propname eq "has" {
             return builtin(sub has($prop) {
                 # XXX: problem: we're not lying hard enough here. we're missing
                 #      both Q objects, which are still hard-coded into the
@@ -537,7 +537,7 @@ class _007::Runtime {
                 return Val::Bool.new(:$value);
             });
         }
-        elsif $propname eq "update" {
+        elsif $obj ~~ Val::Dict && $propname eq "update" {
             return builtin(sub update($newprops) {
                 for $obj.properties.keys {
                     $obj.properties{$_} = $newprops.properties{$_} // $obj.properties{$_};
@@ -545,7 +545,7 @@ class _007::Runtime {
                 return $obj;
             });
         }
-        elsif $propname eq "extend" {
+        elsif $obj ~~ Val::Dict && $propname eq "extend" {
             return builtin(sub extend($newprops) {
                 for $newprops.properties.keys {
                     $obj.properties{$_} = $newprops.properties{$_};

--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -529,10 +529,6 @@ class _007::Runtime {
         }
         elsif $obj ~~ Val::Dict && $propname eq "has" {
             return builtin(sub has($prop) {
-                # XXX: problem: we're not lying hard enough here. we're missing
-                #      both Q objects, which are still hard-coded into the
-                #      substrate, and the special-cased properties
-                #      <get has extend update>
                 my $value = $obj.properties{$prop.value} :exists;
                 return Val::Bool.new(:$value);
             });

--- a/lib/_007/Val.pm6
+++ b/lib/_007/Val.pm6
@@ -63,6 +63,15 @@ class Val::None does Val {
 
 constant NONE is export = Val::None.new;
 
+### ### Object
+###
+### The top type of 007. A featureless object. Everything inherits from this type.
+class Val::Object does Val {
+    method truthy {
+        True
+    }
+}
+
 ### ### Bool
 ###
 ### A type with two values, `true` and `false`. These are often the result
@@ -583,6 +592,7 @@ class Val::Exception does Val {
 class Helper {
     our sub Str($_) {
         when Val::None { "none" }
+        when Val::Object { "<object>" }
         when Val::Bool { .value.lc }
         when Val::Int { .value.Str }
         when Val::Str { .value }

--- a/lib/_007/Val.pm6
+++ b/lib/_007/Val.pm6
@@ -358,95 +358,44 @@ class Val::Array does Val {
 
 our $global-object-id = 0;
 
-### ### Object
+### ### Dict
 ###
-### A mutable unordered collection of key/value properties. An object
-### contains zero or more such properties, each with a unique string
+### A mutable unordered collection of key/value entries. A dict
+### contains zero or more such entries, each with a unique string
 ### name.
 ###
-### The way to create an object from scratch is to use the object term
+### The way to create a dict from scratch is to use the dict term
 ### syntax:
 ###
-###     my o1 = { foo: 42 };        # autoquoted key
-###     my o2 = { "foo": 42 };      # string key
-###     say(o1 == o2);              # --> `true`
-###     my foo = 42;
-###     my o3 = { foo };            # property shorthand
-###     say(o1 == o3);              # --> `true`
+###     my d1 = { foo: 42 };        # autoquoted key
+###     my d2 = { "foo": 42 };      # string key
+###     say(d1 == d2);              # --> `true`
 ###
-###     my o4 = {
-###         greet: func () {
-###             return "hi!";
-###         }
-###     };
-###     my o5 = {
-###         greet() {               # method shorthand
-###             return "hi!";
-###         }
-###     };
-###     say(o4.greet() == o5.greet());  # --> `true`
-###
-### All of the above will create objects of type `Object`, which is
-### the topmost type in the type system. `Object` also has the special
-### property that it can accept any set of keys.
-###
-###     say(type({}));              # --> `<type Object>`
-###
-### There are also two ways to create a new, similar object from an old one.
-###
-###     my o6 = {
-###         name: "James",
-###         job: "librarian"
-###     };
-###     my o7 = o6.update({
-###         job: "secret agent"
-###     });
-###     say(o7);                    # --> `{job: "secret agent", name: "James"}`
-###
-###     my o8 = {
-###         name: "Blofeld"
-###     };
-###     my o9 = o8.extend({
-###         job: "supervillain"
-###     });
-###     say(o9);                    # --> `{job: "supervillain", name: "Blofeld"}`
-###
-### There's a way to extract an array of an object's keys. The order of the keys in
+### There's a way to extract an array of a dict's keys. The order of the keys in
 ### this list is not defined and may even change from call to call.
 ###
-###     my o10 = {
+###     my d3 = {
 ###         one: 1,
 ###         two: 2,
 ###         three: 3
 ###     };
-###     say(o10.keys().sort());     # --> `["one", "three", "two"]`
+###     say(d3.keys().sort());      # --> `["one", "three", "two"]`
 ###
-### You can also ask whether a key exists on an object.
+### You can also ask whether an entry exists in a dict.
 ###
-###     my o11 = {
+###     my d4 = {
 ###         foo: 42,
 ###         bar: none
 ###     };
-###     say(o11.has("foo"));        # --> `true`
-###     say(o11.has("bar"));        # --> `true`
-###     say(o11.has("bazinga"));    # --> `false`
+###     say(d4.has("foo"));        # --> `true`
+###     say(d4.has("bar"));        # --> `true`
+###     say(d4.has("bazinga"));    # --> `false`
 ###
-### Note that the criterion is whether the *key* exists, not whether the
+### Note that the criterion is whether the *entry* exists, not whether the
 ### corresponding value is defined.
 ###
-### Each object has a unique ID, corresponding to references in other
-### languages. Comparison of objects happens by comparing keys and values,
-### not by reference. If you want to do a reference comparison, you need
-### to use the `.id` property:
-###
-###     my o12 = { foo: 5 };
-###     my o13 = { foo: 5 };        # same key/value but different reference
-###     say(o12 == o13);            # --> `true`
-###     say(o12.id == o13.id);      # --> `false`
-###
-class Val::Object does Val {
+class Val::Dict does Val {
     has %.properties{Str};
-    has $.id = $global-object-id++;
 
     method quoted-Str {
         if %*stringification-seen{self.WHICH}++ {
@@ -473,11 +422,11 @@ class Val::Object does Val {
 ###
 ###     say(type(007));         # --> `<type Int>`
 ###     say(type("Bond"));      # --> `<type Str>`
-###     say(type({}));          # --> `<type Object>`
+###     say(type({}));          # --> `<type Dict>`
 ###     say(type(type({})));    # --> `<type Type>`
 ###
 ### 007 comes with a number of built-in types: `None`, `Bool`, `Int`,
-### `Str`, `Array`, `Object`, `Regex`, `Type`, `Block`, `Sub`, `Macro`,
+### `Str`, `Array`, `Dict`, `Regex`, `Type`, `Block`, `Sub`, `Macro`,
 ### and `Exception`.
 ###
 ### There's also a whole hierarchy of Q types, which describe parts of
@@ -526,7 +475,7 @@ class Val::Type does Val {
     }
 
     method create(@properties) {
-        if $.type ~~ Val::Object {
+        if $.type ~~ Val::Dict {
             return $.type.new(:@properties);
         }
         elsif $.type ~~ Val::Int | Val::Str {
@@ -578,8 +527,8 @@ class Val::Func does Val {
     has &.hook = Callable;
     has $.parameterlist;
     has $.statementlist;
-    has Val::Object $.static-lexpad is rw = Val::Object.new;
-    has Val::Object $.outer-frame;
+    has Val::Dict $.static-lexpad is rw = Val::Dict.new;
+    has Val::Dict $.outer-frame;
 
     method new-builtin(&hook, Str $name, $parameterlist, $statementlist) {
         self.bless(:name(Val::Str.new(:value($name))), :&hook, :$parameterlist, :$statementlist);
@@ -639,7 +588,7 @@ class Helper {
         when Val::Str { .value }
         when Val::Regex { .quoted-Str }
         when Val::Array { .quoted-Str }
-        when Val::Object { .quoted-Str }
+        when Val::Dict { .quoted-Str }
         when Val::Type { "<type {.name}>" }
         when Val::Macro { "<macro {.escaped-name}{.pretty-parameters}>" }
         when Val::Func { "<sub {.escaped-name}{.pretty-parameters}>" }

--- a/self-host/runtime.007
+++ b/self-host/runtime.007
@@ -203,7 +203,7 @@ my Runtime = {
             },
             "Q.Prefix": func(op) {
             },
-            "Q.Term.Object": func(term) {
+            "Q.Term.Dict": func(term) {
             },
             "Q.Term.Quasi": func(term) {
             },

--- a/self-host/runtime.007
+++ b/self-host/runtime.007
@@ -36,9 +36,6 @@ my Runtime = {
 
         func find_pad(symbol) {
             my frame = current_frame();
-            # The below check didn't work
-            # while frame.id != NO_OUTER.id {
-            # So trying this instead:
             while frame.has("pad") {
                 if frame.pad.has(symbol) {
                     return frame.pad;

--- a/self-host/runtime.007
+++ b/self-host/runtime.007
@@ -295,5 +295,5 @@ my Runtime = {
     }
 };
 
-my runtime = Runtime.new();
-runtime.run(ast);
+my runtime = Runtime["new"]();
+runtime["run"](ast);

--- a/t/builtins/methods.t
+++ b/t/builtins/methods.t
@@ -333,7 +333,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(Object.create([["foo", 42]]));
+        say(Dict.create([["foo", 42]]));
         .
 
     outputs $program, qq[\{foo: 42\}\n], "Type.create() method to create an Object";

--- a/t/builtins/operators.t
+++ b/t/builtins/operators.t
@@ -545,10 +545,10 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = {}; say(q ~~ Object)
+        my q = {}; say(q ~~ Dict)
         .
 
-    outputs $program, "true\n", "typecheck works for Val::Object";
+    outputs $program, "true\n", "typecheck works for Val::Dict";
 }
 
 {
@@ -557,9 +557,9 @@ use _007::Test;
         say(quasi<Q.Infix> { + } !~~ Q.Prefix);
         say(42 !~~ Int);
         say([4, 2] !~~ Array);
-        say({} !~~ Object);
+        say({} !~~ Dict);
         say(42 !~~ Array);
-        say([4, 2] !~~ Object);
+        say([4, 2] !~~ Dict);
         say({} !~~ Int);
         .
 

--- a/t/builtins/operators.t
+++ b/t/builtins/operators.t
@@ -405,18 +405,18 @@ use _007::Test;
     my $program = q:to/./;
         my a = [1, 2, 3];
         func f() { return 7 };
-        my o = { foo: 12 };
+        my d = { "foo": 1 };
 
         say(-a[1]);
         say(-f());
-        say(-o.foo);
+        say(-d.size());
 
         say(!a[2]);
         say(!f());
-        say(!o.foo);
+        say(!d.size());
         .
 
-    outputs $program, "-2\n-7\n-12\nfalse\nfalse\nfalse\n", "all postfixes are tighter than both prefixes";
+    outputs $program, "-2\n-7\n-1\nfalse\nfalse\nfalse\n", "all postfixes are tighter than both prefixes";
 }
 
 {

--- a/t/features/class.t
+++ b/t/features/class.t
@@ -40,20 +40,20 @@ ensure-feature-flag("CLASS");
 
 {
     my $program = q:to/./;
-        my BuiltinObject;
+        my BuiltinDict;
         BEGIN {
-            BuiltinObject = Object;
+            BuiltinDict = Dict;
         }
         {
-            class Object {
+            class Dict {
             }
 
-            say({} ~~ BuiltinObject);
-            say({} ~~ Object);
+            say({} ~~ BuiltinDict);
+            say({} ~~ Dict);
         }
         .
 
-    outputs $program, "true\nfalse\n", "the `\{\}` syntax uses the built-in Object, even when overridden";
+    outputs $program, "true\nfalse\n", "the `\{\}` syntax uses the built-in Dict, even when overridden";
 }
 
 {

--- a/t/features/objects.t
+++ b/t/features/objects.t
@@ -72,7 +72,7 @@ use _007::Test;
     parse-error
         $program,
         X::Property::Duplicate,
-        "can't have duplicate properties (#85)";
+        "can't have duplicate properties (#85) (II)";
 }
 
 {
@@ -87,14 +87,11 @@ use _007::Test;
         say(o.update({ bond: 8 }));
 
         say({ x: 1 }.extend({ y: 2 }));
-
-        my n = o.id;
-        say("id");
         .
 
     outputs
         $program,
-        qq[true\nfalse\n7\n\{bond: 8, james: "bond"\}\n\{x: 1, y: 2\}\nid\n],
+        qq[true\nfalse\n7\n\{bond: 8, james: "bond"\}\n\{x: 1, y: 2\}\n],
         "built-in pseudo-inherited methods on objects";
 }
 
@@ -137,7 +134,7 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my q = new Object { foo: 42 };
+        my q = new Dict { foo: 42 };
 
         say(q.foo);
         .
@@ -145,7 +142,7 @@ use _007::Test;
     outputs
         $program,
         qq[42\n],
-        "can create a Val::Object by explicitly naming 'Object'";
+        "can create a Val::Dict by explicitly naming 'Dict'";
 }
 
 {

--- a/t/features/objects.t
+++ b/t/features/objects.t
@@ -16,15 +16,6 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        my o = { a: 1 };
-        say(o.a);
-        .
-
-    outputs $program, "1\n", "can access an object's property (dot syntax)";
-}
-
-{
-    my $program = q:to/./;
         my o = { b: 7 };
         say(o["b"]);
         .
@@ -136,7 +127,7 @@ use _007::Test;
     my $program = q:to/./;
         my q = new Dict { foo: 42 };
 
-        say(q.foo);
+        say(q["foo"]);
         .
 
     outputs
@@ -181,7 +172,7 @@ use _007::Test;
             }
         };
 
-        say(obj.meth());
+        say(obj["meth"]());
         .
 
     outputs $program, "7\n", "a `return` inside of a (short-form) method is fine";

--- a/t/features/quasi.t
+++ b/t/features/quasi.t
@@ -210,15 +210,14 @@ use _007::Test;
         say(type(quasi<Q.Term> { none }));
         say(type(quasi<Q.Term> { "James Bond" }));
         say(type(quasi<Q.Term> { [0, 0, 7] }));
-        say(type(quasi<Q.Term> { new Object { james: "Bond" } }));
+        say(type(quasi<Q.Term> { { james: "Bond" } }));
         say(type(quasi<Q.Term> { quasi { say("oh, james!") } }));
         say(type(quasi<Q.Term> { (0 + 0 + 7) }));
         .
 
     outputs $program,
         <Literal.Int Literal.None Literal.Str
-            Term.Array Term.Object Term.Quasi
-            Infix>\
+        Term.Array Term.Dict Term.Quasi Infix>\
             .map({ "<type Q.$_>\n" }).join,
         "quasi<Q.Term>";
 }
@@ -233,10 +232,10 @@ use _007::Test;
 
 {
     my $program = q:to/./;
-        say(type(quasi<Q.Term.Object> { new Object { james: "Bond" } }));
+        say(type(quasi<Q.Term.Dict> { { james: "Bond" } }));
         .
 
-    outputs $program, "<type Q.Term.Object>\n", "quasi<Q.Term.Object>";
+    outputs $program, "<type Q.Term.Dict>\n", "quasi<Q.Term.Dict>";
 }
 
 {

--- a/t/features/types.t
+++ b/t/features/types.t
@@ -74,4 +74,14 @@ use _007::Test;
         "Q is a built-in type (#201)";
 }
 
+{
+    outputs 'my o = new Object {}; say(o); say(type(o))', "<object>\n<type Object>\n",
+        "can create a new Object";
+}
+
+{
+    outputs 'for [42, [], "", Int, Array, Type, Object] -> x { say(x ~~ Object) }', "true\n" x 7,
+        "everything is an object";
+}
+
 done-testing;


### PR DESCRIPTION
This change has been long in the coming. It's big, and I'm not 100% sure it's complete, but at this point it's a definite net improvement.

Highlights:

* New `Dict` type. Syntax `{ foo: 42 }` or `{ "foo": 42 }`.
* Objects are still created the same old way: `new Exception { message: "..." }`
* The methods that used to sit on `Val::Object` now sit on `Val::Dict`.
* `Object` is now a real top type in 007.

Closes #184.
Closes #144.
Closes #261.