### PR TITLE
Add test coverage based on fuzzing Builtins.pm6

### DIFF
--- a/fuzzer-builtins.txt
+++ b/fuzzer-builtins.txt
@@ -1,0 +1,375 @@
+Builtins.pm6 (373 lines)
+============
+  1         use _007::Val;
+  2         use _007::Q;
+  3         use _007::OpScope;
+  4         use _007::Equal;
+  5         
+  6         class X::Control::Exit is Exception {
+  7 [ff565]     has Int $.exit-code;
+  8         }
+  9         
+ 10         sub wrap($_) {
+ 11 [!!!!!]     when Val | Q { $_ }
+ 12 [6bbcf]     when Nil  { NONE }
+ 13 [8008f]     when Bool { Val::Bool.new(:value($_)) }
+ 14 [1238d]     when Int  { Val::Int.new(:value($_)) }
+ 15 [184ba]     when Str  { Val::Str.new(:value($_)) }
+ 16 [45f1d]     when Array | Seq | List { Val::Array.new(:elements(.map(&wrap))) }
+ 17 [ff565]     default { die "Got some unknown value of type ", .^name }
+ 18         }
+ 19         
+ 20         subset ValOrQ of Any where Val | Q;
+ 21         
+ 22         sub assert-type(:$value, ValOrQ:U :$type, Str :$operation) {
+ 23             die X::TypeCheck.new(:$operation, :got($value), :expected($type))
+ 24 [72be1]         unless $value ~~ $type;
+ 25         }
+ 26         
+ 27         sub assert-nonzero(:$value, :$operation, :$numerator) {
+ 28             die X::Numeric::DivideByZero.new(:using($operation), :$numerator)
+ 29 [02cf4]         if $value == 0;
+ 30         }
+ 31         
+ 32         multi less-value($l, $) {
+ 33 [ff565]     assert-type(:value($l), :type(Val::Int), :operation<less>);
+ 34         }
+ 35 [45b95] multi less-value(Val::Int $l, Val::Int $r) { $l.value < $r.value }
+ 36 [93a7d] multi less-value(Val::Str $l, Val::Str $r) { $l.value lt $r.value }
+ 37         multi more-value($l, $) {
+ 38 [ff565]     assert-type(:value($l), :type(Val::Int), :operation<more>);
+ 39         }
+ 40 [bb18c] multi more-value(Val::Int $l, Val::Int $r) { $l.value > $r.value }
+ 41 [5993c] multi more-value(Val::Str $l, Val::Str $r) { $l.value gt $r.value }
+ 42         
+ 43         my role Placeholder {
+ 44             has $.qtype;
+ 45             has $.assoc;
+ 46             has %.precedence;
+ 47         }
+ 48         my class Placeholder::MacroOp does Placeholder {
+ 49         }
+ 50         sub macro-op(:$qtype, :$assoc?, :%precedence?) {
+ 51             Placeholder::MacroOp.new(:$qtype, :$assoc, :%precedence);
+ 52         }
+ 53         
+ 54         my class Placeholder::Op does Placeholder {
+ 55             has &.fn;
+ 56         }
+ 57         sub op(&fn, :$qtype, :$assoc?, :%precedence?) {
+ 58             Placeholder::Op.new(:&fn, :$qtype, :$assoc, :%precedence);
+ 59         }
+ 60         
+ 61         my @builtins =
+ 62 [f31b3]     say => -> *$args {
+ 63                 # implementation in Runtime.pm
+ 64             },
+ 65 [cc2dd]     prompt => sub ($arg) {
+ 66                 # implementation in Runtime.pm
+ 67             },
+ 68 [936bf]     type => -> $arg { Val::Type.of($arg.WHAT) },
+ 69 [10278]     exit => -> $int = Val::Int.new(:value(0)) {
+ 70 [6234b]         assert-type(:value($int), :type(Val::Int), :operation<exit>);
+ 71                 my $exit-code = $int.value % 256;
+ 72 [ff565]         die X::Control::Exit.new(:$exit-code);
+ 73             },
+ 74 [c09c4]     assertType => -> $value, $type {
+ 75 [48a81]         assert-type(:value($type), :type(Val::Type), :operation("assertType (checking the Type parameter)"));
+ 76 [ff565]         assert-type(:$value, :type($type.type), :operation<assertType>);
+ 77             },
+ 78         
+ 79             # OPERATORS (from loosest to tightest within each category)
+ 80         
+ 81             # assignment precedence
+ 82             'infix:=' => macro-op(
+ 83                 :qtype(Q::Infix::Assignment),
+ 84 [3c68a]         :assoc<right>,
+ 85             ),
+ 86         
+ 87             # disjunctive precedence
+ 88             'infix:||' => macro-op(
+ 89                 :qtype(Q::Infix::Or),
+ 90             ),
+ 91             'infix://' => macro-op(
+ 92                 :qtype(Q::Infix::DefinedOr),
+ 93 [cd6f8]         :precedence{ equiv => "infix:||" },
+ 94             ),
+ 95         
+ 96             # conjunctive precedence
+ 97             'infix:&&' => macro-op(
+ 98                 :qtype(Q::Infix::And),
+ 99             ),
+100         
+101             # comparison precedence
+102             'infix:==' => op(
+103                 sub ($lhs, $rhs) {
+104 [4ecb0]             my %*equality-seen;
+105 [0630a]             return wrap(equal-value($lhs, $rhs));
+106                 },
+107 [a8c92]         :qtype(Q::Infix),
+108 [74fec]         :assoc<non>,
+109             ),
+110             'infix:!=' => op(
+111                 sub ($lhs, $rhs) {
+112 [edce4]             my %*equality-seen;
+113 [3699c]             return wrap(!equal-value($lhs, $rhs))
+114                 },
+115 [707c8]         :qtype(Q::Infix),
+116 [c756f]         :precedence{ equiv => "infix:==" },
+117             ),
+118             'infix:<' => op(
+119                 sub ($lhs, $rhs) {
+120 [31277]             return wrap(less-value($lhs, $rhs))
+121                 },
+122 [!!!!!]         :qtype(Q::Infix),
+123 [ce8d2]         :precedence{ equiv => "infix:==" },
+124             ),
+125             'infix:<=' => op(
+126                 sub ($lhs, $rhs) {
+127 [59b9d]             my %*equality-seen;
+128 [17a67]             return wrap(less-value($lhs, $rhs) || equal-value($lhs, $rhs))
+129                 },
+130 [!!!!!]         :qtype(Q::Infix),
+131 [ad694]         :precedence{ equiv => "infix:==" },
+132             ),
+133             'infix:>' => op(
+134                 sub ($lhs, $rhs) {
+135 [5da7e]             return wrap(more-value($lhs, $rhs) )
+136                 },
+137 [!!!!!]         :qtype(Q::Infix),
+138 [6dfd8]         :precedence{ equiv => "infix:==" },
+139             ),
+140             'infix:>=' => op(
+141                 sub ($lhs, $rhs) {
+142 [4fdd3]             my %*equality-seen;
+143 [6dc38]             return wrap(more-value($lhs, $rhs) || equal-value($lhs, $rhs))
+144                 },
+145 [!!!!!]         :qtype(Q::Infix),
+146 [d1515]         :precedence{ equiv => "infix:==" },
+147             ),
+148             'infix:~~' => op(
+149                 sub ($lhs, $rhs) {
+150 [!!!!!]             assert-type(:value($rhs), :type(Val::Type), :operation<~~>);
+151         
+152 [a4ea6]             return wrap($rhs.type ~~ Val::Object || $lhs ~~ $rhs.type);
+153                 },
+154 [85ddd]         :qtype(Q::Infix),
+155 [cc282]         :precedence{ equiv => "infix:==" },
+156             ),
+157             'infix:!~~' => op(
+158                 sub ($lhs, $rhs) {
+159 [!!!!!]             assert-type(:value($rhs), :type(Val::Type), :operation<!~~>);
+160         
+161 [6a24d]             return wrap($rhs.type !~~ Val::Object && $lhs !~~ $rhs.type);
+162                 },
+163 [!!!!!]         :qtype(Q::Infix),
+164 [6d608]         :precedence{ equiv => "infix:==" },
+165             ),
+166         
+167             # concatenation precedence
+168             'infix:~' => op(
+169                 sub ($lhs, $rhs) {
+170 [05d9f]             return wrap($lhs.Str ~ $rhs.Str);
+171                 },
+172 [6e4de]         :qtype(Q::Infix),
+173             ),
+174         
+175             # additive precedence
+176             'infix:+' => op(
+177                 sub ($lhs, $rhs) {
+178 [2a3a4]             assert-type(:value($lhs), :type(Val::Int), :operation<+>);
+179 [df874]             assert-type(:value($rhs), :type(Val::Int), :operation<+>);
+180         
+181 [78759]             return wrap($lhs.value + $rhs.value);
+182                 },
+183 [9e7d5]         :qtype(Q::Infix),
+184             ),
+185             'infix:-' => op(
+186                 sub ($lhs, $rhs) {
+187 [!!!!!]             assert-type(:value($lhs), :type(Val::Int), :operation<->);
+188 [!!!!!]             assert-type(:value($rhs), :type(Val::Int), :operation<->);
+189         
+190 [35ab8]             return wrap($lhs.value - $rhs.value);
+191                 },
+192 [cfb72]         :qtype(Q::Infix),
+193             ),
+194         
+195             # multiplicative precedence
+196             'infix:*' => op(
+197                 sub ($lhs, $rhs) {
+198 [!!!!!]             assert-type(:value($lhs), :type(Val::Int), :operation<*>);
+199 [!!!!!]             assert-type(:value($rhs), :type(Val::Int), :operation<*>);
+200         
+201 [d8015]             return wrap($lhs.value * $rhs.value);
+202                 },
+203 [78107]         :qtype(Q::Infix),
+204             ),
+205             'infix:%' => op(
+206                 sub ($lhs, $rhs) {
+207 [!!!!!]             assert-type(:value($lhs), :type(Val::Int), :operation<%>);
+208 [a123c]             assert-type(:value($rhs), :type(Val::Int), :operation<%>);
+209 [88029]             assert-nonzero(:value($rhs.value), :operation("infix:<%>"), :numerator($lhs.value));
+210         
+211 [459a4]             return wrap($lhs.value % $rhs.value);
+212                 },
+213 [deb12]         :qtype(Q::Infix),
+214             ),
+215             'infix:%%' => op(
+216                 sub ($lhs, $rhs) {
+217 [!!!!!]             assert-type(:value($lhs), :type(Val::Int), :operation<%%>);
+218 [89933]             assert-type(:value($rhs), :type(Val::Int), :operation<%%>);
+219 [11624]             assert-nonzero(:value($rhs.value), :operation("infix:<%%>"), :numerator($lhs.value));
+220         
+221 [e8628]             return wrap($lhs.value %% $rhs.value);
+222                 },
+223 [46062]         :qtype(Q::Infix),
+224             ),
+225             'infix:divmod' => op(
+226                 sub ($lhs, $rhs) {
+227 [!!!!!]             assert-type(:value($lhs), :type(Val::Int), :operation<divmod>);
+228 [0a931]             assert-type(:value($rhs), :type(Val::Int), :operation<divmod>);
+229 [1012f]             assert-nonzero(:value($rhs.value), :operation("infix:<divmod>"), :numerator($lhs.value));
+230         
+231                     return Val::Array.new(:elements([
+232 [c7bb1]                 wrap($lhs.value div $rhs.value),
+233 [c1e3d]                 wrap($lhs.value % $rhs.value),
+234                     ]));
+235                 },
+236 [a5ebc]         :qtype(Q::Infix),
+237             ),
+238         
+239             # prefixes
+240             'prefix:~' => op(
+241                 sub prefix-str($expr) {
+242 [fd0d5]             Val::Str.new(:value($expr.Str));
+243                 },
+244 [c9dbc]         :qtype(Q::Prefix),
+245             ),
+246             'prefix:+' => op(
+247                 sub prefix-plus($_) {
+248 [3c2f5]             when Val::Str {
+249                         return wrap(.value.Int)
+250                             if .value ~~ /^ '-'? \d+ $/;
+251 [dcf31]                 proceed;
+252                     }
+253 [f20e8]             when Val::Int {
+254 [dcf31]                 return $_;
+255                     }
+256 [1808a]             assert-type(:value($_), :type(Val::Int), :operation("prefix:<+>"));
+257                 },
+258 [90ce6]         :qtype(Q::Prefix),
+259             ),
+260             'prefix:-' => op(
+261                 sub prefix-minus($_) {
+262 [d47dc]             when Val::Str {
+263                         return wrap(-.value.Int)
+264                             if .value ~~ /^ '-'? \d+ $/;
+265 [a2667]                 proceed;
+266                     }
+267 [3295b]             when Val::Int {
+268 [a2667]                 return wrap(-.value);
+269                     }
+270 [e1079]             assert-type(:value($_), :type(Val::Int), :operation("prefix:<->"));
+271                 },
+272 [b4cd9]         :qtype(Q::Prefix),
+273             ),
+274             'prefix:?' => op(
+275                 sub ($a) {
+276 [d4215]             return wrap(?$a.truthy)
+277                 },
+278 [ecd0c]         :qtype(Q::Prefix),
+279             ),
+280             'prefix:!' => op(
+281                 sub ($a) {
+282 [44a80]             return wrap(!$a.truthy)
+283                 },
+284 [66406]         :qtype(Q::Prefix),
+285             ),
+286             'prefix:^' => op(
+287                 sub ($n) {
+288 [5abf9]             assert-type(:value($n), :type(Val::Int), :operation("prefix:<^>"));
+289         
+290 [0dd48]             return wrap([^$n.value]);
+291                 },
+292 [5887a]         :qtype(Q::Prefix),
+293             ),
+294         
+295             # postfixes
+296             'postfix:[]' => macro-op(
+297                 :qtype(Q::Postfix::Index),
+298             ),
+299             'postfix:()' => macro-op(
+300                 :qtype(Q::Postfix::Call),
+301             ),
+302             'postfix:.' => macro-op(
+303                 :qtype(Q::Postfix::Property),
+304             ),
+305         ;
+306         
+307         for Val::.keys.map({ "Val::" ~ $_ }) -> $name {
+308             my $type = ::($name);
+309 [ff565]     push @builtins, ($type.^name.subst("Val::", "") => Val::Type.of($type));
+310         }
+311 [b219c] push @builtins, "Q" => Val::Type.of(Q);
+312         
+313         my $opscope = _007::OpScope.new();
+314         
+315         sub install-op($name, $placeholder) {
+316             $name ~~ /^ (prefix | infix | postfix) ':' (.+) $/
+317                 or die "This shouldn't be an op";
+318             my $type = ~$0;
+319             my $opname = ~$1;
+320             my $qtype = $placeholder.qtype;
+321             my $assoc = $placeholder.assoc;
+322             my %precedence = $placeholder.precedence;
+323 [ff565]     $opscope.install($type, $opname, $qtype, :$assoc, :%precedence);
+324         }
+325         
+326         my &ditch-sigil = { $^str.substr(1) };
+327         my &parameter = { Q::Parameter.new(:identifier(Q::Identifier.new(:name(Val::Str.new(:$^value))))) };
+328         
+329         @builtins.=map({
+330             when .value ~~ Val::Type {
+331                 .key => .value;
+332             }
+333             when .value ~~ Block {
+334                 my @elements = .value.signature.params».name».&ditch-sigil».&parameter;
+335 [3f72a]         if .key eq "say" {
+336 [9ff83]             @elements = parameter("...args");
+337                 }
+338                 my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
+339                 my $statementlist = Q::StatementList.new();
+340                 .key => Val::Func.new-builtin(.value, .key, $parameterlist, $statementlist);
+341             }
+342             when .value ~~ Placeholder::MacroOp {
+343                 my $name = .key;
+344 [a2140]         install-op($name, .value);
+345                 my @elements = .value.qtype.attributes».name».substr(2).grep({ $_ ne "identifier" })».&parameter;
+346                 my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
+347                 my $statementlist = Q::StatementList.new();
+348                 .key => Val::Func.new-builtin(sub () {}, $name, $parameterlist, $statementlist);
+349             }
+350             when .value ~~ Placeholder::Op {
+351                 my $name = .key;
+352 [a7d8b]         install-op($name, .value);
+353                 my &fn = .value.fn;
+354                 my @elements = &fn.signature.params».name».&ditch-sigil».&parameter;
+355                 my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
+356                 my $statementlist = Q::StatementList.new();
+357                 .key => Val::Func.new-builtin(&fn, $name, $parameterlist, $statementlist);
+358             }
+359 [ff565]     default { die "Unknown type {.value.^name}" }
+360         });
+361         
+362         my $builtins-pad = Val::Dict.new;
+363 [49b7a] for @builtins -> Pair (:key($name), :$value) {
+364 [ff565]     $builtins-pad.properties{$name} = $value;
+365         }
+366         
+367 [49b7a] sub builtins-pad() is export {
+368 [ff565]     return $builtins-pad;
+369         }
+370         
+371 [599ab] sub opscope() is export {
+372 [efaea]     return $opscope;
+373         }

--- a/lib/_007/Builtins.pm6
+++ b/lib/_007/Builtins.pm6
@@ -103,7 +103,6 @@ my @builtins =
             my %*equality-seen;
             return wrap(equal-value($lhs, $rhs));
         },
-        :qtype(Q::Infix),
         :assoc<non>,
     ),
     'infix:!=' => op(
@@ -111,14 +110,12 @@ my @builtins =
             my %*equality-seen;
             return wrap(!equal-value($lhs, $rhs))
         },
-        :qtype(Q::Infix),
         :precedence{ equiv => "infix:==" },
     ),
     'infix:<' => op(
         sub ($lhs, $rhs) {
             return wrap(less-value($lhs, $rhs))
         },
-        :qtype(Q::Infix),
         :precedence{ equiv => "infix:==" },
     ),
     'infix:<=' => op(
@@ -126,14 +123,12 @@ my @builtins =
             my %*equality-seen;
             return wrap(less-value($lhs, $rhs) || equal-value($lhs, $rhs))
         },
-        :qtype(Q::Infix),
         :precedence{ equiv => "infix:==" },
     ),
     'infix:>' => op(
         sub ($lhs, $rhs) {
             return wrap(more-value($lhs, $rhs) )
         },
-        :qtype(Q::Infix),
         :precedence{ equiv => "infix:==" },
     ),
     'infix:>=' => op(
@@ -141,7 +136,6 @@ my @builtins =
             my %*equality-seen;
             return wrap(more-value($lhs, $rhs) || equal-value($lhs, $rhs))
         },
-        :qtype(Q::Infix),
         :precedence{ equiv => "infix:==" },
     ),
     'infix:~~' => op(
@@ -150,7 +144,6 @@ my @builtins =
 
             return wrap($rhs.type ~~ Val::Object || $lhs ~~ $rhs.type);
         },
-        :qtype(Q::Infix),
         :precedence{ equiv => "infix:==" },
     ),
     'infix:!~~' => op(
@@ -159,7 +152,6 @@ my @builtins =
 
             return wrap($rhs.type !~~ Val::Object && $lhs !~~ $rhs.type);
         },
-        :qtype(Q::Infix),
         :precedence{ equiv => "infix:==" },
     ),
 
@@ -168,7 +160,6 @@ my @builtins =
         sub ($lhs, $rhs) {
             return wrap($lhs.Str ~ $rhs.Str);
         },
-        :qtype(Q::Infix),
     ),
 
     # additive precedence
@@ -179,7 +170,6 @@ my @builtins =
 
             return wrap($lhs.value + $rhs.value);
         },
-        :qtype(Q::Infix),
     ),
     'infix:-' => op(
         sub ($lhs, $rhs) {
@@ -188,7 +178,6 @@ my @builtins =
 
             return wrap($lhs.value - $rhs.value);
         },
-        :qtype(Q::Infix),
     ),
 
     # multiplicative precedence
@@ -199,7 +188,6 @@ my @builtins =
 
             return wrap($lhs.value * $rhs.value);
         },
-        :qtype(Q::Infix),
     ),
     'infix:%' => op(
         sub ($lhs, $rhs) {
@@ -209,7 +197,6 @@ my @builtins =
 
             return wrap($lhs.value % $rhs.value);
         },
-        :qtype(Q::Infix),
     ),
     'infix:%%' => op(
         sub ($lhs, $rhs) {
@@ -219,7 +206,6 @@ my @builtins =
 
             return wrap($lhs.value %% $rhs.value);
         },
-        :qtype(Q::Infix),
     ),
     'infix:divmod' => op(
         sub ($lhs, $rhs) {
@@ -232,7 +218,6 @@ my @builtins =
                 wrap($lhs.value % $rhs.value),
             ]));
         },
-        :qtype(Q::Infix),
     ),
 
     # prefixes
@@ -240,7 +225,6 @@ my @builtins =
         sub prefix-str($expr) {
             Val::Str.new(:value($expr.Str));
         },
-        :qtype(Q::Prefix),
     ),
     'prefix:+' => op(
         sub prefix-plus($_) {
@@ -254,7 +238,6 @@ my @builtins =
             }
             assert-type(:value($_), :type(Val::Int), :operation("prefix:<+>"));
         },
-        :qtype(Q::Prefix),
     ),
     'prefix:-' => op(
         sub prefix-minus($_) {
@@ -268,19 +251,16 @@ my @builtins =
             }
             assert-type(:value($_), :type(Val::Int), :operation("prefix:<->"));
         },
-        :qtype(Q::Prefix),
     ),
     'prefix:?' => op(
         sub ($a) {
             return wrap(?$a.truthy)
         },
-        :qtype(Q::Prefix),
     ),
     'prefix:!' => op(
         sub ($a) {
             return wrap(!$a.truthy)
         },
-        :qtype(Q::Prefix),
     ),
     'prefix:^' => op(
         sub ($n) {
@@ -288,7 +268,6 @@ my @builtins =
 
             return wrap([^$n.value]);
         },
-        :qtype(Q::Prefix),
     ),
 
     # postfixes

--- a/lib/_007/Builtins.pm6
+++ b/lib/_007/Builtins.pm6
@@ -8,7 +8,6 @@ class X::Control::Exit is Exception {
 }
 
 sub wrap($_) {
-    when Val | Q { $_ }
     when Nil  { NONE }
     when Bool { Val::Bool.new(:value($_)) }
     when Int  { Val::Int.new(:value($_)) }

--- a/t/builtins/operators.t
+++ b/t/builtins/operators.t
@@ -383,6 +383,72 @@ use _007::Test;
 
 {
     my $program = q:to/./;
+        say(38 - "4");
+        .
+
+    runtime-error
+        $program,
+        X::TypeCheck,
+        "subtracting non-ints is an error (rhs)";
+}
+
+{
+    my $program = q:to/./;
+        say(true - 4);
+        .
+
+    runtime-error
+        $program,
+        X::TypeCheck,
+        "subtracting non-ints is an error (lhs)";
+}
+
+{
+    my $program = q:to/./;
+        say(38 * "4");
+        .
+
+    runtime-error
+        $program,
+        X::TypeCheck,
+        "multiplying non-ints is an error (rhs)";
+}
+
+{
+    my $program = q:to/./;
+        say(true * 4);
+        .
+
+    runtime-error
+        $program,
+        X::TypeCheck,
+        "multiplying non-ints is an error (lhs)";
+}
+
+{
+    my $program = q:to/./;
+        say("four" % 4);
+        .
+
+    runtime-error
+        $program,
+        X::TypeCheck,
+        "moduloing non-ints is an error (lhs)";
+}
+
+{
+    my $program = q:to/./;
+        say("four" %% 4);
+        .
+
+    runtime-error
+        $program,
+        X::TypeCheck,
+        "checking divisibility of non-ints is an error (lhs)";
+}
+
+{
+    my $program = q:to/./;
         say(38 ~ "4");
         .
 
@@ -662,6 +728,28 @@ use _007::Test;
 
 {
     my $program = q:to/./;
+        say( 7 ~~ "Int" );
+        .
+
+    runtime-error
+        $program,
+        X::TypeCheck,
+        "rhs of ~~ must be of type Type";
+}
+
+{
+    my $program = q:to/./;
+        say( 7 !~~ "Int" );
+        .
+
+    runtime-error
+        $program,
+        X::TypeCheck,
+        "rhs of !~~ must be of type Type";
+}
+
+{
+    my $program = q:to/./;
         say( 5 divmod 2 );
         say( 5 divmod -2 );
         .
@@ -690,6 +778,17 @@ use _007::Test;
         .
 
     outputs $program, "foo4\n4bar\n", "~ binds looser than +";
+}
+
+{
+    my $program = q:to/./;
+        say("30" divmod 5);
+        .
+
+    runtime-error
+        $program,
+        X::TypeCheck,
+        "divmodding non-ints is an error (lhs)";
 }
 
 done-testing;


### PR DESCRIPTION
Here's the fuzzer output for `Builtins.pm6`:

    Builtins.pm6 (373 lines)
    ============
      1         use _007::Val;
      2         use _007::Q;
      3         use _007::OpScope;
      4         use _007::Equal;
      5         
      6         class X::Control::Exit is Exception {
      7 [ff565]     has Int $.exit-code;
      8         }
      9         
     10         sub wrap($_) {
     11 [!!!!!]     when Val | Q { $_ }
     12 [6bbcf]     when Nil  { NONE }
     13 [8008f]     when Bool { Val::Bool.new(:value($_)) }
     14 [1238d]     when Int  { Val::Int.new(:value($_)) }
     15 [184ba]     when Str  { Val::Str.new(:value($_)) }
     16 [45f1d]     when Array | Seq | List { Val::Array.new(:elements(.map(&wrap))) }
     17 [ff565]     default { die "Got some unknown value of type ", .^name }
     18         }
     19         
     20         subset ValOrQ of Any where Val | Q;
     21         
     22         sub assert-type(:$value, ValOrQ:U :$type, Str :$operation) {
     23             die X::TypeCheck.new(:$operation, :got($value), :expected($type))
     24 [72be1]         unless $value ~~ $type;
     25         }
     26         
     27         sub assert-nonzero(:$value, :$operation, :$numerator) {
     28             die X::Numeric::DivideByZero.new(:using($operation), :$numerator)
     29 [02cf4]         if $value == 0;
     30         }
     31         
     32         multi less-value($l, $) {
     33 [ff565]     assert-type(:value($l), :type(Val::Int), :operation<less>);
     34         }
     35 [45b95] multi less-value(Val::Int $l, Val::Int $r) { $l.value < $r.value }
     36 [93a7d] multi less-value(Val::Str $l, Val::Str $r) { $l.value lt $r.value }
     37         multi more-value($l, $) {
     38 [ff565]     assert-type(:value($l), :type(Val::Int), :operation<more>);
     39         }
     40 [bb18c] multi more-value(Val::Int $l, Val::Int $r) { $l.value > $r.value }
     41 [5993c] multi more-value(Val::Str $l, Val::Str $r) { $l.value gt $r.value }
     42         
     43         my role Placeholder {
     44             has $.qtype;
     45             has $.assoc;
     46             has %.precedence;
     47         }
     48         my class Placeholder::MacroOp does Placeholder {
     49         }
     50         sub macro-op(:$qtype, :$assoc?, :%precedence?) {
     51             Placeholder::MacroOp.new(:$qtype, :$assoc, :%precedence);
     52         }
     53         
     54         my class Placeholder::Op does Placeholder {
     55             has &.fn;
     56         }
     57         sub op(&fn, :$qtype, :$assoc?, :%precedence?) {
     58             Placeholder::Op.new(:&fn, :$qtype, :$assoc, :%precedence);
     59         }
     60         
     61         my @builtins =
     62 [f31b3]     say => -> *$args {
     63                 # implementation in Runtime.pm
     64             },
     65 [cc2dd]     prompt => sub ($arg) {
     66                 # implementation in Runtime.pm
     67             },
     68 [936bf]     type => -> $arg { Val::Type.of($arg.WHAT) },
     69 [10278]     exit => -> $int = Val::Int.new(:value(0)) {
     70 [6234b]         assert-type(:value($int), :type(Val::Int), :operation<exit>);
     71                 my $exit-code = $int.value % 256;
     72 [ff565]         die X::Control::Exit.new(:$exit-code);
     73             },
     74 [c09c4]     assertType => -> $value, $type {
     75 [48a81]         assert-type(:value($type), :type(Val::Type), :operation("assertType (checking the Type parameter)"));
     76 [ff565]         assert-type(:$value, :type($type.type), :operation<assertType>);
     77             },
     78         
     79             # OPERATORS (from loosest to tightest within each category)
     80         
     81             # assignment precedence
     82             'infix:=' => macro-op(
     83                 :qtype(Q::Infix::Assignment),
     84 [3c68a]         :assoc<right>,
     85             ),
     86         
     87             # disjunctive precedence
     88             'infix:||' => macro-op(
     89                 :qtype(Q::Infix::Or),
     90             ),
     91             'infix://' => macro-op(
     92                 :qtype(Q::Infix::DefinedOr),
     93 [cd6f8]         :precedence{ equiv => "infix:||" },
     94             ),
     95         
     96             # conjunctive precedence
     97             'infix:&&' => macro-op(
     98                 :qtype(Q::Infix::And),
     99             ),
    100         
    101             # comparison precedence
    102             'infix:==' => op(
    103                 sub ($lhs, $rhs) {
    104 [4ecb0]             my %*equality-seen;
    105 [0630a]             return wrap(equal-value($lhs, $rhs));
    106                 },
    107 [a8c92]         :qtype(Q::Infix),
    108 [74fec]         :assoc<non>,
    109             ),
    110             'infix:!=' => op(
    111                 sub ($lhs, $rhs) {
    112 [edce4]             my %*equality-seen;
    113 [3699c]             return wrap(!equal-value($lhs, $rhs))
    114                 },
    115 [707c8]         :qtype(Q::Infix),
    116 [c756f]         :precedence{ equiv => "infix:==" },
    117             ),
    118             'infix:<' => op(
    119                 sub ($lhs, $rhs) {
    120 [31277]             return wrap(less-value($lhs, $rhs))
    121                 },
    122 [!!!!!]         :qtype(Q::Infix),
    123 [ce8d2]         :precedence{ equiv => "infix:==" },
    124             ),
    125             'infix:<=' => op(
    126                 sub ($lhs, $rhs) {
    127 [59b9d]             my %*equality-seen;
    128 [17a67]             return wrap(less-value($lhs, $rhs) || equal-value($lhs, $rhs))
    129                 },
    130 [!!!!!]         :qtype(Q::Infix),
    131 [ad694]         :precedence{ equiv => "infix:==" },
    132             ),
    133             'infix:>' => op(
    134                 sub ($lhs, $rhs) {
    135 [5da7e]             return wrap(more-value($lhs, $rhs) )
    136                 },
    137 [!!!!!]         :qtype(Q::Infix),
    138 [6dfd8]         :precedence{ equiv => "infix:==" },
    139             ),
    140             'infix:>=' => op(
    141                 sub ($lhs, $rhs) {
    142 [4fdd3]             my %*equality-seen;
    143 [6dc38]             return wrap(more-value($lhs, $rhs) || equal-value($lhs, $rhs))
    144                 },
    145 [!!!!!]         :qtype(Q::Infix),
    146 [d1515]         :precedence{ equiv => "infix:==" },
    147             ),
    148             'infix:~~' => op(
    149                 sub ($lhs, $rhs) {
    150 [!!!!!]             assert-type(:value($rhs), :type(Val::Type), :operation<~~>);
    151         
    152 [a4ea6]             return wrap($rhs.type ~~ Val::Object || $lhs ~~ $rhs.type);
    153                 },
    154 [85ddd]         :qtype(Q::Infix),
    155 [cc282]         :precedence{ equiv => "infix:==" },
    156             ),
    157             'infix:!~~' => op(
    158                 sub ($lhs, $rhs) {
    159 [!!!!!]             assert-type(:value($rhs), :type(Val::Type), :operation<!~~>);
    160         
    161 [6a24d]             return wrap($rhs.type !~~ Val::Object && $lhs !~~ $rhs.type);
    162                 },
    163 [!!!!!]         :qtype(Q::Infix),
    164 [6d608]         :precedence{ equiv => "infix:==" },
    165             ),
    166         
    167             # concatenation precedence
    168             'infix:~' => op(
    169                 sub ($lhs, $rhs) {
    170 [05d9f]             return wrap($lhs.Str ~ $rhs.Str);
    171                 },
    172 [6e4de]         :qtype(Q::Infix),
    173             ),
    174         
    175             # additive precedence
    176             'infix:+' => op(
    177                 sub ($lhs, $rhs) {
    178 [2a3a4]             assert-type(:value($lhs), :type(Val::Int), :operation<+>);
    179 [df874]             assert-type(:value($rhs), :type(Val::Int), :operation<+>);
    180         
    181 [78759]             return wrap($lhs.value + $rhs.value);
    182                 },
    183 [9e7d5]         :qtype(Q::Infix),
    184             ),
    185             'infix:-' => op(
    186                 sub ($lhs, $rhs) {
    187 [!!!!!]             assert-type(:value($lhs), :type(Val::Int), :operation<->);
    188 [!!!!!]             assert-type(:value($rhs), :type(Val::Int), :operation<->);
    189         
    190 [35ab8]             return wrap($lhs.value - $rhs.value);
    191                 },
    192 [cfb72]         :qtype(Q::Infix),
    193             ),
    194         
    195             # multiplicative precedence
    196             'infix:*' => op(
    197                 sub ($lhs, $rhs) {
    198 [!!!!!]             assert-type(:value($lhs), :type(Val::Int), :operation<*>);
    199 [!!!!!]             assert-type(:value($rhs), :type(Val::Int), :operation<*>);
    200         
    201 [d8015]             return wrap($lhs.value * $rhs.value);
    202                 },
    203 [78107]         :qtype(Q::Infix),
    204             ),
    205             'infix:%' => op(
    206                 sub ($lhs, $rhs) {
    207 [!!!!!]             assert-type(:value($lhs), :type(Val::Int), :operation<%>);
    208 [a123c]             assert-type(:value($rhs), :type(Val::Int), :operation<%>);
    209 [88029]             assert-nonzero(:value($rhs.value), :operation("infix:<%>"), :numerator($lhs.value));
    210         
    211 [459a4]             return wrap($lhs.value % $rhs.value);
    212                 },
    213 [deb12]         :qtype(Q::Infix),
    214             ),
    215             'infix:%%' => op(
    216                 sub ($lhs, $rhs) {
    217 [!!!!!]             assert-type(:value($lhs), :type(Val::Int), :operation<%%>);
    218 [89933]             assert-type(:value($rhs), :type(Val::Int), :operation<%%>);
    219 [11624]             assert-nonzero(:value($rhs.value), :operation("infix:<%%>"), :numerator($lhs.value));
    220         
    221 [e8628]             return wrap($lhs.value %% $rhs.value);
    222                 },
    223 [46062]         :qtype(Q::Infix),
    224             ),
    225             'infix:divmod' => op(
    226                 sub ($lhs, $rhs) {
    227 [!!!!!]             assert-type(:value($lhs), :type(Val::Int), :operation<divmod>);
    228 [0a931]             assert-type(:value($rhs), :type(Val::Int), :operation<divmod>);
    229 [1012f]             assert-nonzero(:value($rhs.value), :operation("infix:<divmod>"), :numerator($lhs.value));
    230         
    231                     return Val::Array.new(:elements([
    232 [c7bb1]                 wrap($lhs.value div $rhs.value),
    233 [c1e3d]                 wrap($lhs.value % $rhs.value),
    234                     ]));
    235                 },
    236 [a5ebc]         :qtype(Q::Infix),
    237             ),
    238         
    239             # prefixes
    240             'prefix:~' => op(
    241                 sub prefix-str($expr) {
    242 [fd0d5]             Val::Str.new(:value($expr.Str));
    243                 },
    244 [c9dbc]         :qtype(Q::Prefix),
    245             ),
    246             'prefix:+' => op(
    247                 sub prefix-plus($_) {
    248 [3c2f5]             when Val::Str {
    249                         return wrap(.value.Int)
    250                             if .value ~~ /^ '-'? \d+ $/;
    251 [dcf31]                 proceed;
    252                     }
    253 [f20e8]             when Val::Int {
    254 [dcf31]                 return $_;
    255                     }
    256 [1808a]             assert-type(:value($_), :type(Val::Int), :operation("prefix:<+>"));
    257                 },
    258 [90ce6]         :qtype(Q::Prefix),
    259             ),
    260             'prefix:-' => op(
    261                 sub prefix-minus($_) {
    262 [d47dc]             when Val::Str {
    263                         return wrap(-.value.Int)
    264                             if .value ~~ /^ '-'? \d+ $/;
    265 [a2667]                 proceed;
    266                     }
    267 [3295b]             when Val::Int {
    268 [a2667]                 return wrap(-.value);
    269                     }
    270 [e1079]             assert-type(:value($_), :type(Val::Int), :operation("prefix:<->"));
    271                 },
    272 [b4cd9]         :qtype(Q::Prefix),
    273             ),
    274             'prefix:?' => op(
    275                 sub ($a) {
    276 [d4215]             return wrap(?$a.truthy)
    277                 },
    278 [ecd0c]         :qtype(Q::Prefix),
    279             ),
    280             'prefix:!' => op(
    281                 sub ($a) {
    282 [44a80]             return wrap(!$a.truthy)
    283                 },
    284 [66406]         :qtype(Q::Prefix),
    285             ),
    286             'prefix:^' => op(
    287                 sub ($n) {
    288 [5abf9]             assert-type(:value($n), :type(Val::Int), :operation("prefix:<^>"));
    289         
    290 [0dd48]             return wrap([^$n.value]);
    291                 },
    292 [5887a]         :qtype(Q::Prefix),
    293             ),
    294         
    295             # postfixes
    296             'postfix:[]' => macro-op(
    297                 :qtype(Q::Postfix::Index),
    298             ),
    299             'postfix:()' => macro-op(
    300                 :qtype(Q::Postfix::Call),
    301             ),
    302             'postfix:.' => macro-op(
    303                 :qtype(Q::Postfix::Property),
    304             ),
    305         ;
    306         
    307         for Val::.keys.map({ "Val::" ~ $_ }) -> $name {
    308             my $type = ::($name);
    309 [ff565]     push @builtins, ($type.^name.subst("Val::", "") => Val::Type.of($type));
    310         }
    311 [b219c] push @builtins, "Q" => Val::Type.of(Q);
    312         
    313         my $opscope = _007::OpScope.new();
    314         
    315         sub install-op($name, $placeholder) {
    316             $name ~~ /^ (prefix | infix | postfix) ':' (.+) $/
    317                 or die "This shouldn't be an op";
    318             my $type = ~$0;
    319             my $opname = ~$1;
    320             my $qtype = $placeholder.qtype;
    321             my $assoc = $placeholder.assoc;
    322             my %precedence = $placeholder.precedence;
    323 [ff565]     $opscope.install($type, $opname, $qtype, :$assoc, :%precedence);
    324         }
    325         
    326         my &ditch-sigil = { $^str.substr(1) };
    327         my &parameter = { Q::Parameter.new(:identifier(Q::Identifier.new(:name(Val::Str.new(:$^value))))) };
    328         
    329         @builtins.=map({
    330             when .value ~~ Val::Type {
    331                 .key => .value;
    332             }
    333             when .value ~~ Block {
    334                 my @elements = .value.signature.params».name».&ditch-sigil».&parameter;
    335 [3f72a]         if .key eq "say" {
    336 [9ff83]             @elements = parameter("...args");
    337                 }
    338                 my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
    339                 my $statementlist = Q::StatementList.new();
    340                 .key => Val::Func.new-builtin(.value, .key, $parameterlist, $statementlist);
    341             }
    342             when .value ~~ Placeholder::MacroOp {
    343                 my $name = .key;
    344 [a2140]         install-op($name, .value);
    345                 my @elements = .value.qtype.attributes».name».substr(2).grep({ $_ ne "identifier" })».&parameter;
    346                 my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
    347                 my $statementlist = Q::StatementList.new();
    348                 .key => Val::Func.new-builtin(sub () {}, $name, $parameterlist, $statementlist);
    349             }
    350             when .value ~~ Placeholder::Op {
    351                 my $name = .key;
    352 [a7d8b]         install-op($name, .value);
    353                 my &fn = .value.fn;
    354                 my @elements = &fn.signature.params».name».&ditch-sigil».&parameter;
    355                 my $parameterlist = Q::ParameterList.new(:parameters(Val::Array.new(:@elements)));
    356                 my $statementlist = Q::StatementList.new();
    357                 .key => Val::Func.new-builtin(&fn, $name, $parameterlist, $statementlist);
    358             }
    359 [ff565]     default { die "Unknown type {.value.^name}" }
    360         });
    361         
    362         my $builtins-pad = Val::Dict.new;
    363 [49b7a] for @builtins -> Pair (:key($name), :$value) {
    364 [ff565]     $builtins-pad.properties{$name} = $value;
    365         }
    366         
    367 [49b7a] sub builtins-pad() is export {
    368 [ff565]     return $builtins-pad;
    369         }
    370         
    371 [599ab] sub opscope() is export {
    372 [efaea]     return $opscope;
    373         }

I think line 11 can legit be removed. The remaining 14 look like 14 tests that could be written.