### PR TITLE
Move Q behavior to Runtime.pm6

### DIFF
--- a/lib/_007/Parser/Actions.pm6
+++ b/lib/_007/Parser/Actions.pm6
@@ -194,7 +194,7 @@ class _007::Parser::Actions {
     method statement:BEGIN ($/) {
         my $statement = $<statement>.ast;
         make Q::Statement::BEGIN.new(:$statement);
-        $statement.run($*runtime);
+        $*runtime.run-q($statement);
     }
 
     method statement:class ($/) {

--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -734,7 +734,52 @@ class _007::Runtime {
 
     multi method eval-q(Q::Infix::Assignment $assignment) {
         my $value = self.eval-q($assignment.rhs);
-        self.put-value($assignment.lhs, $value);
+
+        my $lhs = $assignment.lhs;
+
+        given $lhs {
+            when Q::Term::Identifier::Direct {
+                self.put-direct($lhs.frame, $lhs.name.value, $value);
+            }
+            when Q::Term::Identifier {
+                self.put-var($lhs, $value);
+            }
+            when Q::Postfix::Index {
+                given self.eval-q($lhs.operand) {
+                    when Val::Array {
+                        my $index = self.eval-q($lhs.index);
+                        die X::Subscript::NonInteger.new
+                            if $index !~~ Val::Int;
+                        die X::Subscript::TooLarge.new(:value($index.value), :length(+.elements))
+                            if $index.value >= .elements;
+                        die X::Subscript::Negative.new(:$index, :type([]))
+                            if $index.value < 0;
+                        .elements[$index.value] = $value;
+                    }
+                    when Val::Dict | Q {
+                        my $property = self.eval-q($lhs.index);
+                        die X::Subscript::NonString.new
+                            if $property !~~ Val::Str;
+                        my $propname = $property.value;
+                        self.put-property($_, $propname, $value);
+                    }
+                    die X::TypeCheck.new(:operation<indexing>, :got($_), :expected(Val::Array));
+                }
+            }
+            when Q::Postfix::Property {
+                given self.eval-q($lhs.operand) {
+                    when Val::Dict | Q {
+                        my $propname = $lhs.property.name.value;
+                        self.put-property($_, $propname, $value);
+                    }
+                    die "We don't handle this case yet"; # XXX: think more about this case
+                }
+            }
+            when Q::Term::My {
+                self.put-var($lhs.identifier, $value);
+            }
+        }
+
         return $value;
     }
 
@@ -1014,50 +1059,5 @@ class _007::Runtime {
             }
         }
         return NONE;
-    }
-
-    multi method put-value(Q::Term::Identifier $identifier, $value) {
-        self.put-var($identifier, $value);
-    }
-
-    multi method put-value(Q::Term::Identifier::Direct $identifier, $value) {
-        self.put-direct($identifier.frame, $identifier.name.value, $value);
-    }
-
-    multi method put-value(Q::Postfix::Index $op, $value) {
-        given self.eval-q($op.operand) {
-            when Val::Array {
-                my $index = self.eval-q($op.index);
-                die X::Subscript::NonInteger.new
-                    if $index !~~ Val::Int;
-                die X::Subscript::TooLarge.new(:value($index.value), :length(+.elements))
-                    if $index.value >= .elements;
-                die X::Subscript::Negative.new(:$index, :type([]))
-                    if $index.value < 0;
-                .elements[$index.value] = $value;
-            }
-            when Val::Dict | Q {
-                my $property = self.eval-q($op.index);
-                die X::Subscript::NonString.new
-                    if $property !~~ Val::Str;
-                my $propname = $property.value;
-                self.put-property($_, $propname, $value);
-            }
-            die X::TypeCheck.new(:operation<indexing>, :got($_), :expected(Val::Array));
-        }
-    }
-
-    multi method put-value(Q::Postfix::Property $op, $value) {
-        given self.eval-q($op.operand) {
-            when Val::Dict | Q {
-                my $propname = $op.property.name.value;
-                self.put-property($_, $propname, $value);
-            }
-            die "We don't handle this case yet"; # XXX: think more about this case
-        }
-    }
-
-    multi method put-value(Q::Term::My $my, $value) {
-        self.put-value($my.identifier, $value);
     }
 }


### PR DESCRIPTION
A precursor to the real work of #377.

A lot of code has moved out from `Q.pm6` to `Runtime.pm6`. How to _interpret_ the Qtypes is now owned by the latter. This makes sense, as we're moving to being a compiler rather than an interpreter.

Naturally, this diminishes the importance of `Q.pm6`, which is down from ~1100 LOC to ~700 LOC. What remains is the _structure_ of the Qtypes, but not the semantics.

Some of the logic could be simplified as it moved, which is encouraging. The individual commits tell the story.