### PR TITLE
Allow traits without parentheses, as in 'is test'

### DIFF
--- a/lib/_007/Parser/Actions.pm6
+++ b/lib/_007/Parser/Actions.pm6
@@ -217,7 +217,7 @@ class _007::Parser::Actions {
         make Q::TraitList.new(:traits(Val::Array.new(:elements(@traits))));
     }
     method trait($/) {
-        make Q::Trait.new(:identifier($<identifier>.ast), :expr($<EXPR>.ast));
+        make Q::Trait.new(:identifier($<identifier>.ast), :expr(ast-if-any($<EXPR>)));
     }
 
     method blockoid ($/) {

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -112,7 +112,7 @@ grammar _007::Parser::Syntax {
         <trait> *
     }
     token trait {
-        is» <.ws> <identifier> '(' <EXPR> ')'
+        is» <.ws> <identifier> [<.ws> '(' <.ws> <EXPR> ')']?
     }
 
     # requires a <.newpad> before invocation

--- a/t/features/funcs.t
+++ b/t/features/funcs.t
@@ -268,4 +268,16 @@ use _007::Test;
     outputs $program, "<func ()>\n", "an anonymous func stringifies without a name";
 }
 
+{
+    my $program = q:to/./;
+        func foo() is test {
+            say("OH HAI");
+        }
+
+        foo();
+        .
+
+    outputs $program, "OH HAI\n", "traits don't have to be followed by parentheses";
+}
+
 done-testing;


### PR DESCRIPTION
I get that this is a weird thing to put up next to #505, but I suddenly felt like giving us an early version of #417, and being able to write `is test` is a precursor to that.

As a bonus, this will get us slightly closer to being able to write "real tests" as part of #498.