### PR TITLE
Forbid whitespace in identifiers

### DIFF
--- a/examples/in.007
+++ b/examples/in.007
@@ -20,7 +20,7 @@ func infix:<in>(value, container) is equiv(infix:<~~>) {
     }
 }
 
-func infix:<not in>(value, container) is equiv(infix:<!~~>) {
+func infix:<!in>(value, container) is equiv(infix:<!~~>) {
     if container ~~ Array {
         for container -> elem {
             if elem == value {
@@ -49,9 +49,9 @@ say(8 in [1, 2, 3, 4]);                 # false
 say("foo" in "foolish");                # true
 say("I" in "team");                     # false
 
-say("job" not in { name: "James" });    # true
-say("name" not in { name: "James" });   # false
-say("d" not in ["a", "b", "c"]);        # true
-say("b" not in ["a", "b", "c"]);        # false
-say("we" not in "Kansas");              # true
-say("pi" not in "pie");                 # false
+say("job" !in { name: "James" });    # true
+say("name" !in { name: "James" });   # false
+say("d" !in ["a", "b", "c"]);        # true
+say("b" !in ["a", "b", "c"]);        # false
+say("we" !in "Kansas");              # true
+say("pi" !in "pie");                 # false

--- a/lib/_007/Parser/Syntax.pm6
+++ b/lib/_007/Parser/Syntax.pm6
@@ -1,6 +1,12 @@
 use _007::Val;
 use _007::Q;
 
+class X::Syntax::WhitespaceInIdentifier is Exception {
+    method message {
+        "Cannot have whitespace in identifier";
+    }
+}
+
 sub check-feature-flag($feature, $word) {
     my $flag = "FLAG_007_{$word}";
     die "{$feature} is experimental and requires \%*ENV<{$flag}> to be set"
@@ -365,6 +371,12 @@ grammar _007::Parser::Syntax {
             [ <?after \w> || <.panic("identifier")> ]
             [ [':<' [ '\\>' | '\\\\' | <-[>]> ]+ '>']
             | [':«' [ '\\»' | '\\\\' | <-[»]> ]+ '»'] ]?
+        {
+            my $identifier = ~$/;
+            if $identifier ~~ /\s/ {
+                die X::Syntax::WhitespaceInIdentifier.new;
+            }
+        }
     }
 
     rule argumentlist {


### PR DESCRIPTION
Since our only infraction was `not in` in `examples/in.007`, change this operator to `!in`.

Closes #531.