### PR TITLE
Add 007-ish exceptions when substr'ing outside of string

### DIFF
--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -435,9 +435,12 @@ class _007::Runtime {
         }
         elsif $obj ~~ Val::Str && $propname eq "substr" {
             return builtin(sub substr($pos, $chars) {
-                return Val::Str.new(:value($obj.value.substr(
-                    $pos.value,
-                    $chars.value)));
+                my $s = $obj.value;
+
+                die X::Subscript::TooLarge.new(:value($pos.value), :length($s.chars))
+                    if $pos.value >= $s.chars + 1;
+
+                return Val::Str.new(:value($s.substr($pos.value, $chars.value)));
             });
         }
         elsif $obj ~~ Val::Str && $propname eq "contains" {

--- a/lib/_007/Runtime.pm6
+++ b/lib/_007/Runtime.pm6
@@ -440,6 +440,9 @@ class _007::Runtime {
                 die X::Subscript::TooLarge.new(:value($pos.value), :length($s.chars))
                     if $pos.value >= $s.chars + 1;
 
+                die X::Subscript::Negative.new(:value($pos.value))
+                    if $pos.value < 0;
+
                 return Val::Str.new(:value($s.substr($pos.value, $chars.value)));
             });
         }

--- a/t/builtins/methods.t
+++ b/t/builtins/methods.t
@@ -154,7 +154,18 @@ use _007::Test;
     runtime-error
         $program,
         X::Subscript::TooLarge,
-        "substr() can be out of range";
+        "substr() starting index can't be too large";
+}
+
+{
+    my $program = q:to/./;
+        "abc".substr(-2, 1);
+        .
+
+    runtime-error
+        $program,
+        X::Subscript::Negative,
+        "substr() starting index can't be negative";
 }
 
 {

--- a/t/builtins/methods.t
+++ b/t/builtins/methods.t
@@ -140,9 +140,21 @@ use _007::Test;
     my $program = q:to/./;
         say("abc".substr(0, 1));
         say("abc".substr(0, 5));
+        say("abc".substr(3, 1));
         .
 
-    outputs $program, "a\nabc\n", "substr() picks out a substring of a string";
+    outputs $program, "a\nabc\n\n", "substr() picks out a substring of a string";
+}
+
+{
+    my $program = q:to/./;
+        "abc".substr(4, 1);
+        .
+
+    runtime-error
+        $program,
+        X::Subscript::TooLarge,
+        "substr() can be out of range";
 }
 
 {


### PR DESCRIPTION
Before this PR, the exceptions happened on the Perl 6 level, and were propagated up in a confusing way to the 007 user.

Also added some sad-path tests for this.

Closes #525.